### PR TITLE
Fix svg charts resizing

### DIFF
--- a/allure-report/allure-report-face/src/main/webapp/js/charts/charts.js
+++ b/allure-report/allure-report-face/src/main/webapp/js/charts/charts.js
@@ -26,19 +26,20 @@ angular.module('allure.charts.util', [],function ($provide) {
             };
         }
     })
-    .factory('d3Util', function (d3, $window) {
+    .factory('d3Util', function (d3, $window, $rootScope) {
         function SvgViewport(elm, config) {
             // explicitly declare height of element, because chrome can't do it itself
             function updateSize() {
+                $svg.remove();
                 var width = $element.width(),
                     height = $element.height(),
                     elmRatio = width/height;
-                if(elmRatio > ratio && height) {
-                    width = height*ratio;
+                if (!height || elmRatio < ratio) {
+                    height = width / ratio;
+                } else {
+                    width = height * ratio;
                 }
-                else {
-                    height = width/ratio;
-                }
+                $svg.appendTo($element);
                 $svg.css({width: width, height: height});
             }
             config = angular.extend({}, config);
@@ -52,7 +53,9 @@ angular.module('allure.charts.util', [],function ($provide) {
                     viewBox: "0 0 " + viewportWidth + " " + viewportHeight
                 }),
                 $svg = angular.element(svg.node());
-            updateSize();
+            $rootScope.$watch(function() {
+                return $element.width();
+            }, updateSize);
             angular.element($window).on('resize', updateSize);
 
             var container = svg.append('g').classed('container-group', true).attr({transform: 'translate(' + config.margin.left + ',' + config.margin.top + ')'});

--- a/allure-report/allure-report-face/src/test/webapp/unit/charts/charts.js
+++ b/allure-report/allure-report-face/src/test/webapp/unit/charts/charts.js
@@ -1,12 +1,12 @@
 /*global describe, it, beforeEach, afterEach, expect, spyOn, jasmine, angular, inject, module, d3 */
 describe('Allure chart directives', function () {
     'use strict';
+    beforeEach(module('allure.charts.util'));
     describe('Tooltip', function() {
         var $document,
             d3,
             tooltip,
             Tooltip;
-        beforeEach(module('allure.charts.util'));
         beforeEach(inject(function (_$document_, _d3_, d3Tooltip) {
             Tooltip = d3Tooltip;
             d3 = _d3_;
@@ -50,6 +50,72 @@ describe('Allure chart directives', function () {
         afterEach(function() {
             tooltip.destroy();
             expect($document.find('.d3-tooltip').length).toBe(0);
+        });
+    });
+
+    describe('SvgViewport', function() {
+        var $rootScope,
+            d3Util,
+            wrapper;
+        beforeEach(inject(function (_$rootScope_, _d3Util_) {
+            d3Util = _d3Util_;
+            $rootScope = _$rootScope_;
+        }));
+
+        beforeEach(function() {
+            wrapper = angular.element('<div></div>');
+            wrapper.appendTo('body');
+        });
+        afterEach(function() {
+            wrapper.remove();
+        });
+
+        function createViewport(wrapper, config) {
+            var viewport = new d3Util.SvgViewport(wrapper[0], config);
+            $rootScope.$apply();
+            return angular.element(viewport.node());
+        }
+
+        function resizeWrapper(width, height) {
+            wrapper.width(width);
+            wrapper.height(height);
+            $rootScope.$apply();
+        }
+
+        it('should create viewport with margins', function() {
+            var viewport = createViewport(wrapper, {width: 100, height: 100}),
+                container = viewport.find('.container-group');
+            expect(container.attr('transform')).toBe('translate(20,20)');
+        });
+
+        it('should fit size in wrapper', function() {
+            var viewport = createViewport(wrapper, {width: 160, height: 110});
+            resizeWrapper(200, null);
+            expect(viewport.width()).toBe(200);
+            expect(viewport.height()).toBe(150);
+        });
+
+        it("should fit to height when viewport is vertical", function() {
+            var viewport = createViewport(wrapper, {width: 110, height: 160});
+            resizeWrapper(200, 200);
+            expect(viewport.width()).toBe(150);
+            expect(viewport.height()).toBe(200);
+        });
+
+        it('should handle element resizing', function() {
+            var viewport = createViewport(wrapper, {width: 160, height: 110});
+            resizeWrapper(200, null);
+            resizeWrapper(400, null);
+            expect(viewport.width()).toBe(400);
+            expect(viewport.height()).toBe(300);
+        });
+
+        it('it should handle size reducing', function() {
+            var viewport = createViewport(wrapper, {width: 160, height: 110});
+            resizeWrapper(200, null);
+            resizeWrapper(100, null);
+            expect(viewport.width()).toBe(100);
+            expect(viewport.height()).toBe(75);
         });
     });
 });


### PR DESCRIPTION
When decrease size of window and then increase, charts didn't restore own size
