### PR TITLE
Arrange timestamps

### DIFF
--- a/allure-report/allure-report-face/src/main/webapp/js/charts/timeline.js
+++ b/allure-report/allure-report-face/src/main/webapp/js/charts/timeline.js
@@ -98,7 +98,7 @@ angular.module('allure.charts.timeline', ['allure.charts.util']).directive('time
                 data.forEach(function(item) {
                     if(!results.some(function(result) {
                         var lastItem = result[result.length-1];
-                        if(lastItem.time.stop < item.time.start) {
+                        if(lastItem.time.stop <= item.time.start) {
                             result.push(item);
                             return true;
                         }

--- a/allure-report/allure-report-face/src/test/webapp/unit/charts/timeline.js
+++ b/allure-report/allure-report-face/src/test/webapp/unit/charts/timeline.js
@@ -18,7 +18,8 @@ describe('Timeline', function() {
     function createTimeline() {
         createElement('<div timeline range="range"><timestamp data="time" ng-repeat="time in times"></div>', {times: [
             {time: {start: 0, duration: 15, stop: 15}, title: 'test', uid: 'uid', status: 'PASSED'},
-            {time: {start: 5, duration: 17, stop: 22}, title: 'test2', uid: 'uid2', status: 'BROKEN'}
+            {time: {start: 5, duration: 17, stop: 22}, title: 'test2', uid: 'uid2', status: 'BROKEN'},
+            {time: {start: 15, duration: 11, stop: 26}, title: 'test3', uid: 'uid3', status: 'PASSED'}
         ]});
         $timeout.flush();
     }
@@ -39,19 +40,19 @@ describe('Timeline', function() {
 
     it('should create and update timeline', function() {
         createTimeline();
-        expect(elem.find('.bar').length).toBe(2);
-        scope.times.push({time: {start: 23, duration: 7, stop: 30}, title: 'test3', uid: 'uid3', status: 'FAILED'});
+        expect(elem.find('.bar').length).toBe(3);
+        scope.times.push({time: {start: 23, duration: 7, stop: 30}, title: 'test4', uid: 'uid4', status: 'FAILED'});
         scope.$apply();
         $timeout.flush();
-        expect(elem.find('.bar').length).toBe(3);
+        expect(elem.find('.bar').length).toBe(4);
     });
 
     it('should filter tests with zero duration', function() {
         createTimeline();
-        scope.times.push({time: {start: 33, duration: 0, stop: 33}, title: 'test3', uid: 'uid3', status: 'FAILED'});
+        scope.times.push({time: {start: 33, duration: 0, stop: 33}, title: 'test4', uid: 'uid4', status: 'FAILED'});
         scope.$apply();
         $timeout.flush();
-        expect(elem.find('.bar').length).toBe(2);
+        expect(elem.find('.bar').length).toBe(3);
     });
 
     it('should clear timeline when there is no tests', function() {


### PR DESCRIPTION
Before this items on timeline had a many gaps between themselves (17 rows total):
![image](https://f.cloud.github.com/assets/812240/1723921/a626ef42-6264-11e3-91fd-26268c3c39f0.png)

After that, timestamps arranged more closely (16 rows total):

![image](https://f.cloud.github.com/assets/812240/1723931/d798082c-6264-11e3-9362-a64a9325f078.png)
