### PR TITLE
Skip redundant units in time-axis

### DIFF
--- a/allure-report/allure-report-face/src/main/webapp/js/charts/duration.js
+++ b/allure-report/allure-report-face/src/main/webapp/js/charts/duration.js
@@ -1,22 +1,5 @@
 /* globals angular */
-angular.module('allure.charts.duration', ['allure.charts.util']).directive('duration', function (d3, d3Util, d3Tooltip) {
-    function timeFormat() {
-        var formats = [
-            [d3.time.format("%d"), function(d) { return d.getUTCDay() && d.getUTCDate() != 1; }],
-            [d3.time.format("%I:%M"), function(d) { return d.getUTCHours(); }],
-            [d3.time.format("%Mm"), function(d) { return d.getUTCMinutes(); }],
-            [d3.time.format("%-Ss"), function(d) { return d.getUTCSeconds(); }],
-            [d3.time.format("%Lms"), function(d) { return d.getUTCMilliseconds(); }]
-        ];
-        return function(date) {
-            if(date.valueOf() === 0) {
-                return "0";
-            }
-            var i = formats.length - 1, f = formats[i];
-            while (!f[1](date)) f = formats[--i];
-            return f[0](date);
-        }
-    }
+angular.module('allure.charts.duration', ['allure.charts.util']).directive('duration', function (d3, d3Util, d3Tooltip, d3timeFilter) {
     function DurationBars(element, data) {
         var width = angular.element(element).width()/2.2,
             height = width*0.6,
@@ -43,7 +26,7 @@ angular.module('allure.charts.duration', ['allure.charts.util']).directive('dura
         y.domain([0, d3.max(bins, function(d) {return d.y;})]).nice();
 
         svg.select('.x-axis-group.axis').call(
-            d3.svg.axis().scale(x).orient('bottom').tickFormat(timeFormat())
+            d3.svg.axis().scale(x).orient('bottom').tickFormat(d3timeFilter)
         );
         svg.select('.y-axis-group.axis').call(
             d3.svg.axis().scale(y).orient('left')

--- a/allure-report/allure-report-face/src/main/webapp/js/filters.js
+++ b/allure-report/allure-report-face/src/main/webapp/js/filters.js
@@ -6,6 +6,30 @@ angular.module('allure.filters', [])
             return String(text).replace(/\%VERSION\%/mg, version);
         };
     }])
+    .constant('d3', window.d3)
+    .filter('d3time', function(d3) {
+        function getTotalHours(time) {
+            return Math.floor(time.valueOf()/(3600*1000));
+        }
+        var formats =[
+            [function(date) {return getTotalHours(date)+'h';}, getTotalHours],
+            [d3.time.format.utc("%-Mm"), function(d) { return d.getUTCMinutes(); }],
+            [d3.time.format.utc("%-Ss"), function(d) { return d.getUTCSeconds(); }],
+            [d3.time.format.utc("%-Lms"), function(d) { return d.getUTCMilliseconds(); }]
+        ];
+        return function(time) {
+            if(time.valueOf() === 0) {
+                return "0";
+            }
+            var i = formats.length - 1,
+                format = formats[i];
+            while (!format[1](time)) {
+                i--;
+                format = formats[i];
+            }
+            return format[0](time);
+        }
+    })
     .filter('time', function() {
         'use strict';
         function getTotalHours(time) {

--- a/allure-report/allure-report-face/src/test/webapp/unit/charts/durationSpec.js
+++ b/allure-report/allure-report-face/src/test/webapp/unit/charts/durationSpec.js
@@ -1,9 +1,13 @@
 /*global describe:true, it:true, beforeEach:true, afterEach:true, expect:true, spyOn:true, module:true, inject:true, angular:true, jasmine:true */
 describe('DurationChart', function () {
     'use strict';
-    var scope, elem;
+    var scope, elem, filterSpy;
 
-    beforeEach(module('allure.charts.duration'));
+    beforeEach(module('allure.charts.duration', function($filterProvider) {
+        $filterProvider.register('d3time', function() {
+            return filterSpy = jasmine.createSpy('filterSpy').andCallFake(angular.identity);
+        });
+    }));
     jasmine.qatools.mockD3Tooltip();
 
     var defaultData = {data: [
@@ -38,6 +42,11 @@ describe('DurationChart', function () {
     it('should create graph and distribute testcases in intervals', function() {
         createElement('<div duration data="data"></div>');
         expect(elem.find('.bar').map(extractData).toArray()).toEqual([2, 0, 0, 0, 0, 0, 2, 0, 2]);
+    });
+
+    it('should format ticks using time filter', function() {
+        createElement('<div duration data="data"></div>');
+        expect(filterSpy).toHaveBeenCalled();
     });
 
     it('should create diagram only with zero durations', function() {

--- a/allure-report/allure-report-face/src/test/webapp/unit/filtersSpec.js
+++ b/allure-report/allure-report-face/src/test/webapp/unit/filtersSpec.js
@@ -14,6 +14,20 @@ describe('filter', function () {
         }));
     });
 
+    describe('d3time', function() {
+        it('should print only last time unit', inject(function(d3timeFilter) {
+            expect(d3timeFilter(new Date(0))).toBe('0');
+            expect(d3timeFilter(new Date(300))).toBe('300ms');
+            expect(d3timeFilter(new Date(1000+300))).toBe('300ms');
+            expect(d3timeFilter(new Date(1000))).toBe('1s');
+            expect(d3timeFilter(new Date(61*1000))).toBe('1s');
+            expect(d3timeFilter(new Date(60*1000))).toBe('1m');
+            expect(d3timeFilter(new Date(60*60*1000))).toBe('1h');
+            expect(d3timeFilter(new Date(25*60*60*1000))).toBe('25h');
+            expect(d3timeFilter(new Date(25*60*60*1000+1))).toBe('1ms');
+        }))
+    });
+
     describe('time', function() {
         it('should format time', inject(function(timeFilter) {
             expect(timeFilter(false)).toBe('0');


### PR DESCRIPTION
Now ticks won't be intersect on the narrow screen
Before:
![image](https://f.cloud.github.com/assets/812240/1887979/d5d13a4a-7a06-11e3-9ecc-5d564718abf7.png)

After:
![image](https://f.cloud.github.com/assets/812240/1887991/f7be5110-7a06-11e3-8573-9a6aef10a346.png)
