### PR TITLE
rft - pretty btns for stacktrace in testcases

### DIFF
--- a/allure-report/allure-report-face/src/main/webapp/templates/testcase/testcase.html
+++ b/allure-report/allure-report-face/src/main/webapp/templates/testcase/testcase.html
@@ -37,8 +37,8 @@
 <script type="text/ng-template" id="testcaseFailure.tpl">
     <div class="testcase__status alert-status-{{testcase.status | lowercase}}" ng-show="testcase.status !== 'PASSED'" ng-controller="angular.noop">
         <span class="preformated-text" ng-click="testcaseExpanded = !testcaseExpanded">{{failure.message}}</span>
-        <a class="pull-right clickable" ng-hide="testcaseExpanded" ng-click="testcaseExpanded = true">Show stacktrace</a>
-        <a class="pull-right clickable" ng-show="testcaseExpanded" ng-click="testcaseExpanded = false">Hide stacktrace</a>
+        <span class="pull-right btn btn-default btn-sm btn-status-{{testcase.status|lowercase}}" ng-hide="testcaseExpanded" ng-click="testcaseExpanded = true">Show stacktrace</span>
+        <span class="pull-right btn btn-default btn-sm active btn-status-{{testcase.status|lowercase}}" ng-show="testcaseExpanded" ng-click="testcaseExpanded = false">Hide stacktrace</span>
         <div ng-show="testcaseExpanded" class="testcase__stacktrace preformated-text">{{failure.stackTrace}}</div>
     </div>
 </script>


### PR DESCRIPTION
![btn1](https://cloud.githubusercontent.com/assets/1964214/2840113/0f52035e-d050-11e3-86dd-f23552e68cfd.png)
![btn2](https://cloud.githubusercontent.com/assets/1964214/2840114/0f8f6104-d050-11e3-90c1-e17948d7da13.png)
![btn3](https://cloud.githubusercontent.com/assets/1964214/2840115/0f8f6c9e-d050-11e3-9e1a-c373d5d9f4b3.png)

instead of ugly link:
![btn4](https://cloud.githubusercontent.com/assets/1964214/2840140/6bb1a0d2-d050-11e3-90cf-8eb921293037.png)
