### PR TITLE
allure lifecycle listener (fixes #184)

### DIFF
--- a/allure-java-aspects/src/main/java/ru/yandex/qatools/allure/aspects/AllureAspectUtils.java
+++ b/allure-java-aspects/src/main/java/ru/yandex/qatools/allure/aspects/AllureAspectUtils.java
@@ -9,6 +9,7 @@ import java.util.Arrays;
  *         Date: 24.10.13
  */
 public final class AllureAspectUtils {
+
     private AllureAspectUtils() {
     }
 

--- a/allure-java-aspects/src/main/java/ru/yandex/qatools/allure/aspects/AllureAttachAspects.java
+++ b/allure-java-aspects/src/main/java/ru/yandex/qatools/allure/aspects/AllureAttachAspects.java
@@ -62,6 +62,7 @@ public class AllureAttachAspects {
         } else if (result instanceof byte[]) {
             bytes = (byte[]) result;
         }
+
         Allure.LIFECYCLE.fire(new MakeAttachmentEvent(bytes, attachTitle, attachment.type()));
     }
 

--- a/allure-java-aspects/src/main/java/ru/yandex/qatools/allure/aspects/AllureStepsAspects.java
+++ b/allure-java-aspects/src/main/java/ru/yandex/qatools/allure/aspects/AllureStepsAspects.java
@@ -31,11 +31,10 @@ public class AllureStepsAspects {
 
     @Before("anyMethod() && withStepAnnotation()")
     public void stepStart(JoinPoint joinPoint) {
-        MethodSignature methodSignature = (MethodSignature) joinPoint.getSignature();
-        Step step = methodSignature.getMethod().getAnnotation(Step.class);
+        String stepTitle = createTitle(joinPoint);
 
+        MethodSignature methodSignature = (MethodSignature) joinPoint.getSignature();
         StepStartedEvent startedEvent = new StepStartedEvent(methodSignature.getName());
-        String stepTitle = getTitle(step.value(), methodSignature.getName(), joinPoint.getArgs());
 
         if (!stepTitle.isEmpty()) {
             startedEvent.setTitle(stepTitle);
@@ -53,5 +52,11 @@ public class AllureStepsAspects {
     @AfterReturning(pointcut = "anyMethod() && withStepAnnotation()", returning = "result")
     public void stepStop(JoinPoint joinPoint, Object result) {
         Allure.LIFECYCLE.fire(new StepFinishedEvent());
+    }
+
+    public String createTitle(JoinPoint joinPoint) {
+        MethodSignature methodSignature = (MethodSignature) joinPoint.getSignature();
+        Step step = methodSignature.getMethod().getAnnotation(Step.class);
+        return step == null ? "" : getTitle(step.value(), methodSignature.getName(), joinPoint.getArgs());
     }
 }

--- a/allure-java-commons/src/main/java/ru/yandex/qatools/allure/experimental/LifecycleListener.java
+++ b/allure-java-commons/src/main/java/ru/yandex/qatools/allure/experimental/LifecycleListener.java
@@ -1,0 +1,40 @@
+package ru.yandex.qatools.allure.experimental;
+
+import ru.yandex.qatools.allure.events.*;
+
+/**
+ * @author Dmitry Baev charlie@yandex-team.ru
+ *         Date: 26.05.14
+ */
+public abstract class LifecycleListener {
+
+    public void fire(StepStartedEvent event) {
+    }
+
+    public void fire(StepEvent event) {
+    }
+
+    public void fire(StepFinishedEvent event) {
+    }
+
+    public void fire(TestCaseStartedEvent event) {
+    }
+
+    public void fire(TestCaseEvent event) {
+    }
+
+    public void fire(TestCaseFinishedEvent event) {
+    }
+
+    public void fire(TestSuiteEvent event) {
+    }
+
+    public void fire(TestSuiteFinishedEvent event) {
+    }
+
+    public void fire(ClearStepStorageEvent event) {
+    }
+
+    public void fire(ClearTestStorageEvent event) {
+    }
+}

--- a/allure-java-commons/src/main/java/ru/yandex/qatools/allure/experimental/ListenersNotifier.java
+++ b/allure-java-commons/src/main/java/ru/yandex/qatools/allure/experimental/ListenersNotifier.java
@@ -1,0 +1,186 @@
+package ru.yandex.qatools.allure.experimental;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import ru.yandex.qatools.allure.events.ClearStepStorageEvent;
+import ru.yandex.qatools.allure.events.ClearTestStorageEvent;
+import ru.yandex.qatools.allure.events.StepEvent;
+import ru.yandex.qatools.allure.events.StepFinishedEvent;
+import ru.yandex.qatools.allure.events.StepStartedEvent;
+import ru.yandex.qatools.allure.events.TestCaseEvent;
+import ru.yandex.qatools.allure.events.TestCaseFinishedEvent;
+import ru.yandex.qatools.allure.events.TestCaseStartedEvent;
+import ru.yandex.qatools.allure.events.TestSuiteEvent;
+import ru.yandex.qatools.allure.events.TestSuiteFinishedEvent;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ServiceConfigurationError;
+import java.util.ServiceLoader;
+
+/**
+ * @author Dmitry Baev charlie@yandex-team.ru
+ *         Date: 26.05.14
+ */
+public class ListenersNotifier extends LifecycleListener {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    private List<LifecycleListener> listeners = new ArrayList<>();
+
+    public ListenersNotifier() {
+        this(Thread.currentThread().getContextClassLoader());
+    }
+
+    public ListenersNotifier(ClassLoader classLoader) {
+        loadListeners(ServiceLoader.load(
+                LifecycleListener.class,
+                classLoader
+        ));
+    }
+
+    protected void loadListeners(ServiceLoader<LifecycleListener> loader) {
+        Iterator<LifecycleListener> iterator = loader.iterator();
+        while (hasNextSafely(iterator)) {
+            try {
+                LifecycleListener listener = iterator.next();
+                listeners.add(listener);
+                logger.info(String.format("Found %s: %s", LifecycleListener.class, listener.getClass()));
+            } catch (ServiceConfigurationError e) {
+                logger.error("iterator.next() failed", e);
+            }
+        }
+    }
+
+    protected boolean hasNextSafely(Iterator iterator) {
+        try {
+            return iterator.hasNext();
+        } catch (Exception e) {
+            logger.error("iterator.hasNext() failed", e);
+            return false;
+        }
+    }
+
+    @Override
+    public void fire(StepStartedEvent event) {
+        for (LifecycleListener listener : listeners) {
+            try {
+                listener.fire(event);
+            } catch (Exception e) {
+                logError(listener, e);
+            }
+        }
+    }
+
+    @Override
+    public void fire(StepEvent event) {
+        for (LifecycleListener listener : listeners) {
+            try {
+                listener.fire(event);
+            } catch (Exception e) {
+                logError(listener, e);
+            }
+        }
+    }
+
+    @Override
+    public void fire(StepFinishedEvent event) {
+        for (LifecycleListener listener : listeners) {
+            try {
+                listener.fire(event);
+            } catch (Exception e) {
+                logError(listener, e);
+            }
+        }
+    }
+
+    @Override
+    public void fire(TestCaseStartedEvent event) {
+        for (LifecycleListener listener : listeners) {
+            try {
+                listener.fire(event);
+            } catch (Exception e) {
+                logError(listener, e);
+            }
+        }
+    }
+
+    @Override
+    public void fire(TestCaseEvent event) {
+        for (LifecycleListener listener : listeners) {
+            try {
+                listener.fire(event);
+            } catch (Exception e) {
+                logError(listener, e);
+            }
+        }
+    }
+
+    @Override
+    public void fire(TestCaseFinishedEvent event) {
+        for (LifecycleListener listener : listeners) {
+            try {
+                listener.fire(event);
+            } catch (Exception e) {
+                logError(listener, e);
+            }
+        }
+    }
+
+    @Override
+    public void fire(TestSuiteEvent event) {
+        for (LifecycleListener listener : listeners) {
+            try {
+                listener.fire(event);
+            } catch (Exception e) {
+                logError(listener, e);
+            }
+        }
+    }
+
+    @Override
+    public void fire(TestSuiteFinishedEvent event) {
+        for (LifecycleListener listener : listeners) {
+            try {
+                listener.fire(event);
+            } catch (Exception e) {
+                logError(listener, e);
+            }
+        }
+    }
+
+    @Override
+    public void fire(ClearStepStorageEvent event) {
+        for (LifecycleListener listener : listeners) {
+            try {
+                listener.fire(event);
+            } catch (Exception e) {
+                logError(listener, e);
+            }
+        }
+    }
+
+    @Override
+    public void fire(ClearTestStorageEvent event) {
+        for (LifecycleListener listener : listeners) {
+            try {
+                listener.fire(event);
+            } catch (Exception e) {
+                logError(listener, e);
+            }
+        }
+    }
+
+    private void logError(LifecycleListener listener, Exception e) {
+        logger.error("Error for listener " + listener.getClass(), e);
+    }
+
+    public void addListener(LifecycleListener listener) {
+        listeners.add(listener);
+    }
+
+    public List<LifecycleListener> getListeners() {
+        return listeners;
+    }
+}

--- a/allure-java-commons/src/test/java/ru/yandex/qatools/allure/ListenersNotifierTest.java
+++ b/allure-java-commons/src/test/java/ru/yandex/qatools/allure/ListenersNotifierTest.java
@@ -1,0 +1,128 @@
+package ru.yandex.qatools.allure;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import ru.yandex.qatools.allure.events.ClearStepStorageEvent;
+import ru.yandex.qatools.allure.events.ClearTestStorageEvent;
+import ru.yandex.qatools.allure.events.StepEvent;
+import ru.yandex.qatools.allure.events.StepFinishedEvent;
+import ru.yandex.qatools.allure.events.StepStartedEvent;
+import ru.yandex.qatools.allure.events.TestCaseEvent;
+import ru.yandex.qatools.allure.events.TestCaseFinishedEvent;
+import ru.yandex.qatools.allure.events.TestCaseStartedEvent;
+import ru.yandex.qatools.allure.events.TestSuiteEvent;
+import ru.yandex.qatools.allure.events.TestSuiteFinishedEvent;
+import ru.yandex.qatools.allure.experimental.testdata.SimpleListener;
+import ru.yandex.qatools.allure.model.Step;
+import ru.yandex.qatools.allure.model.TestCaseResult;
+import ru.yandex.qatools.allure.model.TestSuiteResult;
+import ru.yandex.qatools.allure.utils.AllureResultsUtils;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+/**
+ * @author Dmitry Baev charlie@yandex-team.ru
+ *         Date: 04.06.14
+ */
+public class ListenersNotifierTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private Allure allure;
+
+    private final SimpleListener listener = new SimpleListener();
+
+    @Before
+    public void setUp() throws Exception {
+        allure = new Allure();
+        allure.addListener(listener);
+        AllureResultsUtils.setResultsDirectory(folder.newFolder());
+    }
+
+    @Test
+    public void stepStartedEventTest() throws Exception {
+        allure.fire(new StepStartedEvent(""));
+        assertThat(listener.get(SimpleListener.EventType.STEP_STARTED_EVENT), is(1));
+    }
+
+    @Test
+    public void stepEventTest() throws Exception {
+        allure.fire(new StepEvent() {
+            @Override
+            public void process(Step context) {
+            }
+        });
+        assertThat(listener.get(SimpleListener.EventType.STEP_EVENT), is(1));
+    }
+
+    @Test
+    public void stepFinishedEventTest() throws Exception {
+        allure.fire(new StepFinishedEvent());
+        assertThat(listener.get(SimpleListener.EventType.STEP_FINISHED_EVENT), is(1));
+    }
+
+    //
+
+    @Test
+    public void testcaseStartedEventTest() throws Exception {
+        allure.fire(new TestCaseStartedEvent("", ""));
+        assertThat(listener.get(SimpleListener.EventType.TESTCASE_STARTED_EVENT), is(1));
+    }
+
+    @Test
+    public void testcaseEventTest() throws Exception {
+        allure.fire(new TestCaseEvent() {
+            @Override
+            public void process(TestCaseResult context) {
+            }
+        });
+        assertThat(listener.get(SimpleListener.EventType.TESTCASE_EVENT), is(1));
+    }
+
+    @Test
+    public void testcaseFinishedEventTest() throws Exception {
+        allure.fire(new TestCaseFinishedEvent());
+        assertThat(listener.get(SimpleListener.EventType.TESTCASE_FINISHED_EVENT), is(1));
+    }
+
+
+    //
+
+    @Test
+    public void testsuiteEventTest() throws Exception {
+        allure.fire(new TestSuiteEvent() {
+            @Override
+            public String getUid() {
+                return "";
+            }
+
+            @Override
+            public void process(TestSuiteResult context) {
+
+            }
+        });
+        assertThat(listener.get(SimpleListener.EventType.TESTSUITE_EVENT), is(1));
+    }
+
+    @Test
+    public void testsuiteFinishedEventTest() throws Exception {
+        allure.fire(new TestSuiteFinishedEvent(""));
+        assertThat(listener.get(SimpleListener.EventType.TESTSUITE_FINISHED_EVENT), is(1));
+    }
+
+    @Test
+    public void clearStepContextTest() throws Exception {
+        allure.fire(new ClearStepStorageEvent());
+        assertThat(listener.get(SimpleListener.EventType.CLEAR_STEP_STORAGE_EVENT), is(1));
+    }
+
+    @Test
+    public void clearTestContextTest() throws Exception {
+        allure.fire(new ClearTestStorageEvent());
+        assertThat(listener.get(SimpleListener.EventType.CLEAR_TEST_STORAGE_EVENT), is(1));
+    }
+}

--- a/allure-java-commons/src/test/java/ru/yandex/qatools/allure/experimental/ListenersNotifierSPITest.java
+++ b/allure-java-commons/src/test/java/ru/yandex/qatools/allure/experimental/ListenersNotifierSPITest.java
@@ -1,0 +1,32 @@
+package ru.yandex.qatools.allure.experimental;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Dmitry Baev charlie@yandex-team.ru
+ *         Date: 04.06.14
+ */
+public class ListenersNotifierSPITest {
+
+    private ListenersNotifier notifier;
+
+    @Before
+    public void setUp() throws Exception {
+        URL url = getClass().getClassLoader().getResource("testdata/");
+        URLClassLoader classLoader = new URLClassLoader(new URL[]{url}, Thread.currentThread().getContextClassLoader());
+
+        notifier = new ListenersNotifier(classLoader);
+    }
+
+    @Test
+    public void listenersCountTest() throws Exception {
+        assertThat(notifier.getListeners(), hasSize(1));
+    }
+}

--- a/allure-java-commons/src/test/java/ru/yandex/qatools/allure/experimental/testdata/FailingListener.java
+++ b/allure-java-commons/src/test/java/ru/yandex/qatools/allure/experimental/testdata/FailingListener.java
@@ -1,0 +1,14 @@
+package ru.yandex.qatools.allure.experimental.testdata;
+
+import ru.yandex.qatools.allure.experimental.LifecycleListener;
+
+/**
+ * @author Dmitry Baev charlie@yandex-team.ru
+ *         Date: 04.06.14
+ */
+public class FailingListener extends LifecycleListener {
+
+    public FailingListener() throws Exception {
+        throw new Exception("Initialization error");
+    }
+}

--- a/allure-java-commons/src/test/java/ru/yandex/qatools/allure/experimental/testdata/SimpleListener.java
+++ b/allure-java-commons/src/test/java/ru/yandex/qatools/allure/experimental/testdata/SimpleListener.java
@@ -1,0 +1,98 @@
+package ru.yandex.qatools.allure.experimental.testdata;
+
+import ru.yandex.qatools.allure.events.ClearStepStorageEvent;
+import ru.yandex.qatools.allure.events.ClearTestStorageEvent;
+import ru.yandex.qatools.allure.events.StepEvent;
+import ru.yandex.qatools.allure.events.StepFinishedEvent;
+import ru.yandex.qatools.allure.events.StepStartedEvent;
+import ru.yandex.qatools.allure.events.TestCaseEvent;
+import ru.yandex.qatools.allure.events.TestCaseFinishedEvent;
+import ru.yandex.qatools.allure.events.TestCaseStartedEvent;
+import ru.yandex.qatools.allure.events.TestSuiteEvent;
+import ru.yandex.qatools.allure.events.TestSuiteFinishedEvent;
+import ru.yandex.qatools.allure.experimental.LifecycleListener;
+
+import java.util.HashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * @author Dmitry Baev charlie@yandex-team.ru
+ *         Date: 04.06.14
+ */
+public class SimpleListener extends LifecycleListener {
+
+    private final HashMap<EventType, AtomicInteger> counts = new HashMap<>();
+
+    public SimpleListener() {
+        for (EventType type : EventType.values()) {
+            counts.put(type, new AtomicInteger(0));
+        }
+    }
+
+    @Override
+    public void fire(StepStartedEvent event) {
+        counts.get(EventType.STEP_STARTED_EVENT).incrementAndGet();
+    }
+
+    @Override
+    public void fire(StepEvent event) {
+        counts.get(EventType.STEP_EVENT).incrementAndGet();
+    }
+
+    @Override
+    public void fire(StepFinishedEvent event) {
+        counts.get(EventType.STEP_FINISHED_EVENT).incrementAndGet();
+    }
+
+    @Override
+    public void fire(TestCaseStartedEvent event) {
+        counts.get(EventType.TESTCASE_STARTED_EVENT).incrementAndGet();
+    }
+
+    @Override
+    public void fire(TestCaseEvent event) {
+        counts.get(EventType.TESTCASE_EVENT).incrementAndGet();
+    }
+
+    @Override
+    public void fire(TestCaseFinishedEvent event) {
+        counts.get(EventType.TESTCASE_FINISHED_EVENT).incrementAndGet();
+    }
+
+    @Override
+    public void fire(TestSuiteEvent event) {
+        counts.get(EventType.TESTSUITE_EVENT).incrementAndGet();
+    }
+
+    @Override
+    public void fire(TestSuiteFinishedEvent event) {
+        counts.get(EventType.TESTSUITE_FINISHED_EVENT).incrementAndGet();
+    }
+
+    @Override
+    public void fire(ClearStepStorageEvent event) {
+        counts.get(EventType.CLEAR_STEP_STORAGE_EVENT).incrementAndGet();
+    }
+
+    @Override
+    public void fire(ClearTestStorageEvent event) {
+        counts.get(EventType.CLEAR_TEST_STORAGE_EVENT).incrementAndGet();
+    }
+
+    public int get(EventType eventType) {
+        return counts.containsKey(eventType) ? counts.get(eventType).get() : 0;
+    }
+
+    public enum EventType {
+        STEP_STARTED_EVENT,
+        STEP_EVENT,
+        STEP_FINISHED_EVENT,
+        TESTCASE_STARTED_EVENT,
+        TESTCASE_EVENT,
+        TESTCASE_FINISHED_EVENT,
+        TESTSUITE_EVENT,
+        TESTSUITE_FINISHED_EVENT,
+        CLEAR_STEP_STORAGE_EVENT,
+        CLEAR_TEST_STORAGE_EVENT
+    }
+}

--- a/allure-java-commons/src/test/resources/testdata/META-INF/services/ru.yandex.qatools.allure.experimental.LifecycleListener
+++ b/allure-java-commons/src/test/resources/testdata/META-INF/services/ru.yandex.qatools.allure.experimental.LifecycleListener
@@ -1,0 +1,2 @@
+ru.yandex.qatools.allure.experimental.testdata.SimpleListener
+ru.yandex.qatools.allure.experimental.testdata.FailingListener


### PR DESCRIPTION
With help of `ServiceLoader` class and `ru.yandex.qatools.allure.experimental.LifecycleListener` interface you can add litener to be notified for every step, case or suite event.
You can't control test running with this feature.
