### PR TITLE
Parameters processing

### DIFF
--- a/allure-java-annotations/src/main/java/ru/yandex/qatools/allure/annotations/Parameter.java
+++ b/allure-java-annotations/src/main/java/ru/yandex/qatools/allure/annotations/Parameter.java
@@ -1,0 +1,20 @@
+package ru.yandex.qatools.allure.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @author Dmitry Baev charlie@yandex-team.ru
+ *         Date: 19.06.14
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface Parameter {
+
+    String value() default "";
+
+}

--- a/allure-java-aspects/src/main/java/ru/yandex/qatools/allure/aspects/AllureParametersAspects.java
+++ b/allure-java-aspects/src/main/java/ru/yandex/qatools/allure/aspects/AllureParametersAspects.java
@@ -1,0 +1,40 @@
+package ru.yandex.qatools.allure.aspects;
+
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.After;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.aspectj.lang.reflect.FieldSignature;
+import ru.yandex.qatools.allure.Allure;
+import ru.yandex.qatools.allure.annotations.Parameter;
+import ru.yandex.qatools.allure.events.AddParameterEvent;
+
+/**
+ * @author Dmitry Baev charlie@yandex-team.ru
+ *         Date: 19.06.14
+ */
+@Aspect
+public class AllureParametersAspects {
+
+    @Pointcut("@annotation(ru.yandex.qatools.allure.annotations.Parameter)")
+    public void withParameterAnnotation() {
+        //pointcut body, should be empty
+    }
+
+    @Pointcut("set(* *)")
+    public void setValueToAnyField() {
+        //pointcut body, should be empty
+    }
+
+    @After("setValueToAnyField() && withParameterAnnotation()")
+    public void parameterValueChanged(JoinPoint joinPoint) {
+        try {
+            FieldSignature fieldSignature = (FieldSignature) joinPoint.getSignature();
+            Parameter parameter = fieldSignature.getField().getAnnotation(Parameter.class);
+            String name = parameter.value().isEmpty() ? fieldSignature.getName() : parameter.value();
+            Allure.LIFECYCLE.fire(new AddParameterEvent(name, joinPoint.getArgs()[0].toString()));
+        } catch (Exception ignored) {
+        }
+    }
+
+}

--- a/allure-java-commons/src/main/java/ru/yandex/qatools/allure/events/TestCaseStartedEvent.java
+++ b/allure-java-commons/src/main/java/ru/yandex/qatools/allure/events/TestCaseStartedEvent.java
@@ -2,10 +2,16 @@ package ru.yandex.qatools.allure.events;
 
 import ru.yandex.qatools.allure.model.Description;
 import ru.yandex.qatools.allure.model.Label;
+import ru.yandex.qatools.allure.model.Parameter;
+import ru.yandex.qatools.allure.model.ParameterKind;
 import ru.yandex.qatools.allure.model.Status;
 import ru.yandex.qatools.allure.model.TestCaseResult;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Properties;
 
 /**
  * @author Dmitry Baev charlie@yandex-team.ru
@@ -40,7 +46,27 @@ public class TestCaseStartedEvent extends AbstractTestCaseStartedEvent {
         testCase.setTitle(getTitle());
         testCase.setDescription(getDescription());
         testCase.setLabels(getLabels());
+        testCase.getParameters().addAll(getSystemProperties());
     }
+
+    private List<Parameter> getSystemProperties() {
+        List<Parameter> results = new ArrayList<>();
+        Properties properties = System.getProperties();
+        Enumeration<?> enumeration = System.getProperties().propertyNames();
+        while (enumeration.hasMoreElements()) {
+            try {
+                String propertyName = (String) enumeration.nextElement();
+                results.add(new Parameter()
+                                .withName(propertyName)
+                                .withValue(properties.getProperty(propertyName))
+                                .withKind(ParameterKind.SYSTEM_PROPERTY)
+                );
+            } catch (Exception ignored) {
+            }
+        }
+        return results;
+    }
+
 
     /**
      * Sets title using fluent-api

--- a/allure-java-commons/src/test/java/ru/yandex/qatools/allure/events/TestCaseEventTest.java
+++ b/allure-java-commons/src/test/java/ru/yandex/qatools/allure/events/TestCaseEventTest.java
@@ -35,6 +35,7 @@ public class TestCaseEventTest {
         verify(testCase).setLabels(Collections.<Label>emptyList());
         verify(testCase).setStart(anyLong());
         verify(testCase).setStatus(Status.PASSED);
+        verify(testCase).getParameters();
         verifyNoMoreInteractions(testCase);
     }
 
@@ -47,6 +48,7 @@ public class TestCaseEventTest {
         verify(testCase).setLabels(Collections.<Label>emptyList());
         verify(testCase).setStart(anyLong());
         verify(testCase).setStatus(Status.PASSED);
+        verify(testCase).getParameters();
         verifyNoMoreInteractions(testCase);
     }
 
@@ -63,6 +65,7 @@ public class TestCaseEventTest {
         verify(testCase).setLabels(Collections.<Label>emptyList());
         verify(testCase).setStart(anyLong());
         verify(testCase).setStatus(Status.PASSED);
+        verify(testCase).getParameters();
         verifyNoMoreInteractions(testCase);
     }
 
@@ -76,6 +79,7 @@ public class TestCaseEventTest {
         verify(testCase).setLabels(Arrays.asList(label));
         verify(testCase).setStart(anyLong());
         verify(testCase).setStatus(Status.PASSED);
+        verify(testCase).getParameters();
         verifyNoMoreInteractions(testCase);
     }
 

--- a/allure-model/src/main/resources/allure.xsd
+++ b/allure-model/src/main/resources/allure.xsd
@@ -110,6 +110,7 @@
         <xs:attribute name="size" type="xs:int"/>
     </xs:complexType>
 
+    <!--Deprecated, will be removed in 1.4.0-->
     <xs:simpleType name="attachment-type">
         <xs:restriction base="xs:string">
             <xs:enumeration value="txt"/>


### PR DESCRIPTION
_add_ &mdash; `@Parameter` annotation. Values of field with this annotation will be added to report as parameters.

An example:

``` java
@Parameter("My Param")
private String myParameter;

@Test
public void suite2Test() throws Exception {
    myParameter = "papa";
    myParameter = "mapa";
    myParameter = "mama";
}
```

In report will looks like 
![2014-06-23 14 35 19](https://cloud.githubusercontent.com/assets/2149631/3356476/1abd6e58-fac2-11e3-9aa4-4de89e31fd90.png)

Also provide system parameters for each testcase
