### PR TITLE
only failed and broken testcases in report

### DIFF
--- a/allure-java-commons/src/main/java/ru/yandex/qatools/allure/Allure.java
+++ b/allure-java-commons/src/main/java/ru/yandex/qatools/allure/Allure.java
@@ -4,6 +4,7 @@ import ru.yandex.qatools.allure.config.AllureConfig;
 import ru.yandex.qatools.allure.config.AllureModelUtils;
 import ru.yandex.qatools.allure.events.ClearStepStorageEvent;
 import ru.yandex.qatools.allure.events.ClearTestStorageEvent;
+import ru.yandex.qatools.allure.events.TestCasesFilterStatusEvent;
 import ru.yandex.qatools.allure.events.RemoveAttachmentsEvent;
 import ru.yandex.qatools.allure.events.StepEvent;
 import ru.yandex.qatools.allure.events.StepFinishedEvent;
@@ -182,7 +183,12 @@ public class Allure {
 
         testSuiteStorage.remove(suiteUid);
 
-        writeTestSuiteResult(testSuite);
+        new TestCasesFilterStatusEvent(AllureConfig.newInstance().getResultsTestCasesStatusFilter())
+                .process(testSuite);
+
+        if (!testSuite.getTestCases().isEmpty()) {
+            writeTestSuiteResult(testSuite);
+        }
 
         notifier.fire(event);
     }

--- a/allure-java-commons/src/main/java/ru/yandex/qatools/allure/events/TestCasesFilterStatusEvent.java
+++ b/allure-java-commons/src/main/java/ru/yandex/qatools/allure/events/TestCasesFilterStatusEvent.java
@@ -1,0 +1,34 @@
+package ru.yandex.qatools.allure.events;
+
+import ru.yandex.qatools.allure.model.Status;
+import ru.yandex.qatools.allure.model.TestCaseResult;
+import ru.yandex.qatools.allure.model.TestSuiteResult;
+
+import java.util.Collection;
+import java.util.Iterator;
+
+/**
+ * User: eoff (eoff@yandex-team.ru)
+ * Date: 31.07.14
+ */
+public class TestCasesFilterStatusEvent extends AbstractTestSuiteFinishedEvent {
+    private Collection<Status> toHide;
+
+    public TestCasesFilterStatusEvent(Collection<Status> toHide) {
+        this.toHide = toHide;
+    }
+
+    @Override
+    public void process(TestSuiteResult testSuite) {
+        if (toHide.isEmpty()) {
+            return;
+        }
+        Iterator<TestCaseResult> iterator = testSuite.getTestCases().listIterator();
+        while (iterator.hasNext()) {
+            TestCaseResult result = iterator.next();
+            if (toHide.contains(result.getStatus())) {
+                iterator.remove();
+            }
+        }
+    }
+}

--- a/allure-java-commons/src/test/java/ru/yandex/qatools/allure/events/TestCasesFilterStatusEventTest.java
+++ b/allure-java-commons/src/test/java/ru/yandex/qatools/allure/events/TestCasesFilterStatusEventTest.java
@@ -1,0 +1,94 @@
+package ru.yandex.qatools.allure.events;
+
+import org.junit.Test;
+import ru.yandex.qatools.allure.model.Status;
+import ru.yandex.qatools.allure.model.TestCaseResult;
+import ru.yandex.qatools.allure.model.TestSuiteResult;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
+
+/**
+ * @author Dmitry Baev charlie@yandex-team.ru
+ *         Date: 05.05.14
+ */
+public class TestCasesFilterStatusEventTest {
+
+    @Test
+    public void doesNotRemoveAnyInitially() throws Exception {
+        TestSuiteResult testSuiteResult = new TestSuiteResult();
+        testSuiteResult.getTestCases().add(new TestCaseResult().withStatus(Status.PASSED));
+        testSuiteResult.getTestCases().add(new TestCaseResult().withStatus(Status.CANCELED));
+        testSuiteResult.getTestCases().add(new TestCaseResult().withStatus(Status.BROKEN));
+        testSuiteResult.getTestCases().add(new TestCaseResult().withStatus(Status.FAILED));
+        testSuiteResult.getTestCases().add(new TestCaseResult().withStatus(Status.PENDING));
+
+        new TestCasesFilterStatusEvent(new ArrayList<Status>()).process(testSuiteResult);
+        assertThat(testSuiteResult.getTestCases(), hasSize(5));
+    }
+
+
+    @Test
+    public void worksWithEmptySuite() throws Exception {
+        TestSuiteResult result = new TestSuiteResult();
+
+        new TestCasesFilterStatusEvent(Arrays.asList(Status.CANCELED, Status.PASSED)).process(result);
+        assertThat(result.getTestCases(), hasSize(0));
+    }
+
+
+    @Test
+    public void removesTestCaseWithStatus() throws Exception {
+        TestSuiteResult result = new TestSuiteResult();
+        result.getTestCases().add(new TestCaseResult().withStatus(Status.PASSED));
+
+        new TestCasesFilterStatusEvent(Arrays.asList(Status.PASSED)).process(result);
+        assertThat(result.getTestCases(), hasSize(0));
+    }
+
+    @Test
+    public void removesAllTestCasesWithStatus() throws Exception {
+        TestSuiteResult result = new TestSuiteResult();
+        result.getTestCases().add(new TestCaseResult().withStatus(Status.PASSED));
+        result.getTestCases().add(new TestCaseResult().withStatus(Status.PASSED));
+        result.getTestCases().add(new TestCaseResult().withStatus(Status.PASSED));
+
+        new TestCasesFilterStatusEvent(Arrays.asList(Status.PASSED)).process(result);
+        assertThat(result.getTestCases(), hasSize(0));
+    }
+
+    @Test
+    public void removesOnlyTestCasesWithStatus() throws Exception {
+        TestSuiteResult result = new TestSuiteResult();
+        TestCaseResult case1 = new TestCaseResult().withStatus(Status.CANCELED);
+        result.getTestCases().add(new TestCaseResult().withStatus(Status.PASSED));
+        result.getTestCases().add(new TestCaseResult().withStatus(Status.PASSED));
+        result.getTestCases().add(case1);
+
+        new TestCasesFilterStatusEvent(Arrays.asList(Status.PASSED)).process(result);
+        assertThat(result.getTestCases(), hasSize(1));
+        assertThat(result.getTestCases(), hasItem(case1));
+    }
+
+    @Test
+    public void removesAllTestCasesWithSeveralStatuses() throws Exception {
+        TestSuiteResult testSuiteResult = new TestSuiteResult();
+        TestCaseResult case1 = new TestCaseResult().withStatus(Status.PASSED);
+        TestCaseResult case2 = new TestCaseResult().withStatus(Status.PENDING);
+        testSuiteResult.getTestCases().add(case1);
+        testSuiteResult.getTestCases().add(case2);
+        testSuiteResult.getTestCases().add(new TestCaseResult().withStatus(Status.CANCELED));
+        testSuiteResult.getTestCases().add(new TestCaseResult().withStatus(Status.BROKEN));
+        testSuiteResult.getTestCases().add(new TestCaseResult().withStatus(Status.FAILED));
+        new TestCasesFilterStatusEvent(Arrays.asList(Status.PASSED, Status.PENDING))
+                .process(testSuiteResult);
+        assertThat(testSuiteResult.getTestCases(), hasSize(3));
+        assertThat(testSuiteResult.getTestCases(), not(hasItem(case1)));
+        assertThat(testSuiteResult.getTestCases(), not(hasItem(case2)));
+    }
+}

--- a/allure-model/src/main/java/ru/yandex/qatools/allure/config/AllureConfig.java
+++ b/allure-model/src/main/java/ru/yandex/qatools/allure/config/AllureConfig.java
@@ -2,12 +2,17 @@ package ru.yandex.qatools.allure.config;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import ru.yandex.qatools.allure.model.Status;
 import ru.yandex.qatools.properties.PropertyLoader;
 import ru.yandex.qatools.properties.annotations.Property;
 import ru.yandex.qatools.properties.annotations.Resource;
+import ru.yandex.qatools.properties.annotations.Use;
 
 import java.io.File;
 import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
 
 /**
  * @author Artem Eroshenko eroshenkoam@yandex-team.ru
@@ -53,6 +58,10 @@ public class AllureConfig {
 
     @Property("allure.attachments.encoding")
     private String attachmentsEncoding = "UTF-8";
+
+    @Use(AllureStatusFilterConverter.class)
+    @Property("allure.results.testcases.status.filter")
+    private Collection<Status> resultsTestCasesStatusFilter = new HashSet<>();
 
     private String version = getClass().getPackage().getImplementationVersion();
 
@@ -115,6 +124,16 @@ public class AllureConfig {
 
     public String getVersion() {
         return version;
+    }
+
+    public Collection<Status> getResultsTestCasesStatusFilter() {
+        if (resultsTestCasesStatusFilter.contains(Status.FAILED) ||
+                resultsTestCasesStatusFilter.contains(Status.BROKEN)) {
+            LOGGER.trace("Property \"allure.results.testcases.status.filter\" should not " +
+                    "contain \"failed\" or \"broken\" status");
+            resultsTestCasesStatusFilter.removeAll(Arrays.asList(Status.FAILED, Status.BROKEN));
+        }
+        return resultsTestCasesStatusFilter;
     }
 
     public static AllureConfig newInstance() {

--- a/allure-model/src/main/java/ru/yandex/qatools/allure/config/AllureStatusFilterConverter.java
+++ b/allure-model/src/main/java/ru/yandex/qatools/allure/config/AllureStatusFilterConverter.java
@@ -1,0 +1,37 @@
+package ru.yandex.qatools.allure.config;
+
+import org.apache.commons.beanutils.Converter;
+import ru.yandex.qatools.allure.model.Status;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * User: eoff (eoff@yandex-team.ru)
+ * Date: 04.08.14
+ */
+public class AllureStatusFilterConverter implements Converter {
+    private String delimeter;
+
+    public AllureStatusFilterConverter() {
+        this(",");
+    }
+
+    public AllureStatusFilterConverter(String delimeter) {
+        this.delimeter = delimeter;
+    }
+
+    @Override
+    public Object convert(Class aClass, Object o) {
+        if (!(o instanceof String)) {
+            return new HashSet<Status>();
+        }
+
+        String str = (String) o;
+        Set<Status> set = new HashSet<>();
+        for (String s : str.split(delimeter)) {
+            set.add(Status.fromValue(s.trim()));
+        }
+        return set;
+    }
+}


### PR DESCRIPTION
sometimes there are too many test cases so it is useless to keep all the information about passed tests. 

this pr provides ability to build report only with failed and broken test cases when property "allure.only.failed.cases" is set to "true"
