### PR TITLE
Allow displaying html tags in step title field

### DIFF
--- a/allure-report-face/src/main/webapp/templates/testcase/testcase.html
+++ b/allure-report-face/src/main/webapp/templates/testcase/testcase.html
@@ -55,7 +55,7 @@
         <b class="step__expand" ng-show="hasContent && !expanded">+</b>
         <b class="step__expand" ng-show="hasContent && expanded">-</b>
         <span class="step__time text-muted">[{{step.time.start | date:'HH:mm:ss.sss'}}]</span>
-        <span class="step__title long-line" ng-class="getStepClass(step)">{{step.title}}</span>
+        <span class="step__title long-line" ng-class="getStepClass(step)" ng-bind-html="step.title | linky"></span>
         <span class="text-muted">{{formatSummary(step)}}</span>
     </div>
     <div class="step__content" ng-if="expanded">


### PR DESCRIPTION
This change is allow to display tags like line-breaks (<br>) in step title field. 
(this realisation based-on type of properties field in testcase.html template)

Example:
- in your code of tests:
  @Step("<br>Multi-line<br>step<br>")
- in report it will be:
  [15:13:03.670] 
  Multi-line
  step
  (1 attachment)
