### PR TITLE
Bugfix: exception is now displayed in last failed step when there are multiple failed steps

### DIFF
--- a/allure-report-face/src/main/webapp/js/testcase/testcase.js
+++ b/allure-report-face/src/main/webapp/js/testcase/testcase.js
@@ -26,7 +26,8 @@ angular.module('allure.testcase.controllers', [])
         $scope.failure = testcase.failure;
 
         function findFailedStep(step) {
-            var hasFailed = step.steps.some(findFailedStep);
+            var hasFailed = step.steps.reverse().some(findFailedStep);
+            step.steps.reverse();
             if(isFailed(step) && !hasFailed) {
                 step.failure = $scope.failure;
                 return true;

--- a/allure-report-face/src/main/webapp/js/testcase/testcase.js
+++ b/allure-report-face/src/main/webapp/js/testcase/testcase.js
@@ -26,8 +26,7 @@ angular.module('allure.testcase.controllers', [])
         $scope.failure = testcase.failure;
 
         function findFailedStep(step) {
-            var hasFailed = step.steps.reverse().some(findFailedStep);
-            step.steps.reverse();
+            var hasFailed = step.steps.slice(0).reverse().some(findFailedStep);
             if(isFailed(step) && !hasFailed) {
                 step.failure = $scope.failure;
                 return true;

--- a/allure-report-face/src/test/webapp/unit/testcase/testcaseSpec.js
+++ b/allure-report-face/src/test/webapp/unit/testcase/testcaseSpec.js
@@ -201,13 +201,14 @@ describe('Testcase controllers', function() {
                 status: 'FAILED',
                 steps: [
                     new Step('PASSED'),
+                    new Step('FAILED'),
                     new Step('FAILED', [
                         new Step('PASSED'),
                         new Step('FAILED')
                     ])
                 ]
             });
-            expect(scope.testcase.steps[1].steps[1].failure.error).toBe(scope.failure.error);
+            expect(scope.testcase.steps[2].steps[1].failure.error).toBe(scope.failure.error);
         });
 
         describe('state checks', function() {


### PR DESCRIPTION
Related to issue #191 and pull request #352.
Before:
![_001](https://cloud.githubusercontent.com/assets/2046080/4100784/07664176-30b5-11e4-982d-73f50f2ab889.png)


After:
![_002](https://cloud.githubusercontent.com/assets/2046080/4100785/0cfc1408-30b5-11e4-9917-3a5adf9a827c.png)
