### PR TITLE
Full-page displaying of TC tab from timeline

### DIFF
--- a/allure-report-face/src/main/less/app.less
+++ b/allure-report-face/src/main/less/app.less
@@ -132,7 +132,7 @@
   padding: 15px;
   overflow: hidden;
   .timeline_pane {
-    position: -ms-page;
+    position: fixed;
     height: 100%;
     width: 100%;
     right: 0;


### PR DESCRIPTION
This css changing  allows to display test case tab (from timeline) with no height restriction.
It is actual for one-thread session and multi-step TC (when "<div class="timeline b-island ng-scope">" element has low value of height).

Before:
![before](https://cloud.githubusercontent.com/assets/5477035/4107908/91f3f36e-31ce-11e4-9aa1-fa2f8a3fa443.PNG)

After:
![after](https://cloud.githubusercontent.com/assets/5477035/4107909/91fe4f76-31ce-11e4-8f1c-90f8dba34b90.PNG)
