### PR TITLE
rft - stacktrace and raw btns in assertions as btn-group

### DIFF
--- a/allure-report-face/src/main/webapp/templates/testcase/testcase.html
+++ b/allure-report-face/src/main/webapp/templates/testcase/testcase.html
@@ -42,10 +42,12 @@
 <br/>
 <script type="text/ng-template" id="testcaseFailure.tpl">
     <div class="testcase__status alert-status-{{testcase.status | lowercase}}" ng-show="testcase.status !== 'PASSED'" ng-controller="angular.noop">
+        <div class="btn-group pull-right ">
+            <span class="btn btn-default btn-sm btn-status-{{testcase.status|lowercase}}" ng-click="stacktraceRaw = !stacktraceRaw" ng-class="{'active': stacktraceRaw}">Raw</span>
+            <span class="btn btn-default btn-sm btn-status-{{testcase.status|lowercase}}" ng-click="stacktraceExpanded = !stacktraceExpanded" ng-class="{'active': stacktraceExpanded}">Stacktrace</span>
+        </div>
+
         <span class="preformated-text" ng-click="stacktraceExpanded = !stacktraceExpanded" ng-class="{'testcase__status--raw': stacktraceRaw}">{{failure.message}}</span>
-        <span class="pull-right btn btn-default btn-sm btn-status-{{testcase.status|lowercase}}" ng-click="stacktraceRaw = !stacktraceRaw" ng-class="{'active': stacktraceRaw}">Raw</span>
-        <span class="pull-right btn btn-default btn-sm btn-status-{{testcase.status|lowercase}}" ng-hide="stacktraceExpanded" ng-click="stacktraceExpanded = true">Show stacktrace</span>
-        <span class="pull-right btn btn-default btn-sm active btn-status-{{testcase.status|lowercase}}" ng-show="stacktraceExpanded" ng-click="stacktraceExpanded = false">Hide stacktrace</span>
         <div ng-show="stacktraceExpanded" class="testcase__stacktrace preformated-text" ng-class="{'testcase__status--raw': stacktraceRaw}">{{failure.stackTrace}}</div>
     </div>
 </script>


### PR DESCRIPTION
To avoid situation with long assertions
![btns1](https://cloud.githubusercontent.com/assets/1964214/4272351/8109722c-3ce1-11e4-9fdb-b87bc7da88d4.png)

Now it always it top right corner as btn group
![btn2](https://cloud.githubusercontent.com/assets/1964214/4272362/947a8c92-3ce1-11e4-848d-d7aeaded6973.png)
![btn3](https://cloud.githubusercontent.com/assets/1964214/4272365/98832a88-3ce1-11e4-8483-ac6776bb5486.png)
