### PR TITLE
Changes for TestNg native description.

### DIFF
--- a/allure-testng-adaptor/src/test/java/ru/yandex/qatools/allure/testng/AllureTestListenerMultipleSuitesTest.java
+++ b/allure-testng-adaptor/src/test/java/ru/yandex/qatools/allure/testng/AllureTestListenerMultipleSuitesTest.java
@@ -6,8 +6,16 @@ import org.testng.TestNG;
 import com.beust.jcommander.internal.Lists;
 
 import ru.yandex.qatools.allure.config.AllureModelUtils;
+import ru.yandex.qatools.allure.model.ObjectFactory;
+import ru.yandex.qatools.allure.model.Status;
+import ru.yandex.qatools.allure.model.TestCaseResult;
+import ru.yandex.qatools.allure.model.TestSuiteResult;
 import ru.yandex.qatools.allure.utils.AllureResultsUtils;
 
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBElement;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Unmarshaller;
 import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Validator;
 
@@ -34,7 +42,7 @@ public class AllureTestListenerMultipleSuitesTest {
     public void setUp() throws IOException {
         resultsDir = Files.createTempDirectory(ALLURE_RESULTS);
         AllureResultsUtils.setResultsDirectory(resultsDir.toFile());
-        List<String> suites=Lists.newArrayList();
+        List<String> suites = Lists.newArrayList();
         suites.add(getClass().getResource(SUITE1).getFile());
         suites.add(getClass().getResource(SUITE2).getFile());
         TestNG testNG = new TestNG();
@@ -67,9 +75,24 @@ public class AllureTestListenerMultipleSuitesTest {
     @Test
     public void validateSuiteFilesSameSize() {
     	Iterator<File> iterator = listTestSuiteFiles(resultsDir.toFile()).iterator();
-    	File file1=iterator.next();
-    	File file2=iterator.next();
+    	File file1 = iterator.next();
+    	File file2 = iterator.next();
     	assertThat(file1.length(), is(file2.length()));
+    }
+    
+    @Test 
+    public void validatePendingTest() throws JAXBException {
+        File resultfile = listTestSuiteFiles(resultsDir.toFile()).iterator().next();
+        JAXBContext context = JAXBContext.newInstance(ObjectFactory.class);
+        Unmarshaller unmarshaller = context.createUnmarshaller();
+        @SuppressWarnings("unchecked")
+        JAXBElement<TestSuiteResult> unmarshalledObject =
+                (JAXBElement<TestSuiteResult>) unmarshaller.unmarshal(resultfile);
+        TestCaseResult testResult = unmarshalledObject.getValue().getTestCases().get(0);
+        
+        assertThat(testResult.getStatus(), is(Status.PENDING));
+        assertThat(testResult.getDescription().getValue(), is("This is pending test"));  
+       
     }
     
     private static void deleteNotEmptyDirectory(Path path) throws IOException {

--- a/allure-testng-adaptor/src/test/java/ru/yandex/qatools/allure/testng/AllureTestListenerTest.java
+++ b/allure-testng-adaptor/src/test/java/ru/yandex/qatools/allure/testng/AllureTestListenerTest.java
@@ -4,6 +4,7 @@ import org.junit.*;
 import org.mockito.InOrder;
 import org.testng.ISuite;
 import org.testng.ITestContext;
+import org.testng.ITestNGMethod;
 import org.testng.ITestResult;
 import org.testng.xml.XmlTest;
 
@@ -35,9 +36,9 @@ public class AllureTestListenerTest {
 
         testngListener.setLifecycle(allure);
         
-        ISuite suite=mock(ISuite.class);
+        ISuite suite = mock(ISuite.class);
     	when(suite.getName()).thenReturn(DEFAULT_SUITE_NAME);
-    	XmlTest xmlTest=mock(XmlTest.class);
+    	XmlTest xmlTest = mock(XmlTest.class);
     	when(xmlTest.getName()).thenReturn(DEFAULT_XML_TEST_NAME);
     	testContext = mock(ITestContext.class);
     	when(testContext.getSuite()).thenReturn(suite);
@@ -50,6 +51,9 @@ public class AllureTestListenerTest {
         when(testResult.getName()).thenReturn(DEFAULT_TEST_NAME);
         when(testResult.getTestContext()).thenReturn(testContext);
         doReturn(new Annotation[0]).when(testngListener).getMethodAnnotations(testResult);
+        ITestNGMethod method = mock(ITestNGMethod.class);
+        when(method.getDescription()).thenReturn(null);
+        when(testResult.getMethod()).thenReturn(method);
 
         testngListener.onTestSkipped(testResult);
 
@@ -64,7 +68,9 @@ public class AllureTestListenerTest {
         when(testResult.getTestContext()).thenReturn(testContext);
         when(testResult.getThrowable()).thenReturn(throwable);
         when(testResult.getName()).thenReturn(DEFAULT_TEST_NAME);
-        
+        ITestNGMethod method = mock(ITestNGMethod.class);
+        when(method.getDescription()).thenReturn(null);
+        when(testResult.getMethod()).thenReturn(method);
         doReturn(new Annotation[0]).when(testngListener).getMethodAnnotations(testResult);
 
         testngListener.onTestSkipped(testResult);
@@ -77,7 +83,9 @@ public class AllureTestListenerTest {
         ITestResult testResult = mock(ITestResult.class);
         when(testResult.getTestContext()).thenReturn(testContext);
         when(testResult.getName()).thenReturn(DEFAULT_TEST_NAME);
-        
+        ITestNGMethod method = mock(ITestNGMethod.class);
+        when(method.getDescription()).thenReturn(null);
+        when(testResult.getMethod()).thenReturn(method);        
         doReturn(new Annotation[0]).when(testngListener).getMethodAnnotations(testResult);
 
         testngListener.onTestSkipped(testResult);
@@ -91,7 +99,9 @@ public class AllureTestListenerTest {
         when(testResult.getTestContext()).thenReturn(testContext);
         when(testResult.getThrowable()).thenReturn(new NullPointerException());
         when(testResult.getName()).thenReturn(DEFAULT_TEST_NAME);
-
+        ITestNGMethod method = mock(ITestNGMethod.class);
+        when(method.getDescription()).thenReturn(null);
+        when(testResult.getMethod()).thenReturn(method);       
         doReturn(new Annotation[0]).when(testngListener).getMethodAnnotations(testResult);
 
         testngListener.onTestSkipped(testResult);
@@ -110,7 +120,9 @@ public class AllureTestListenerTest {
         when(testResult.getTestContext()).thenReturn(testContext);
         when(testResult.getName()).thenReturn(DEFAULT_TEST_NAME);
         when(testResult.getParameters()).thenReturn(new Object[] { doubleParameter, stringParameter});
-
+        ITestNGMethod method = mock(ITestNGMethod.class);
+        when(method.getDescription()).thenReturn(null);
+        when(testResult.getMethod()).thenReturn(method);        
         doReturn(new Annotation[0]).when(testngListener).getMethodAnnotations(testResult);
 
         testngListener.onTestStart(testResult);

--- a/allure-testng-adaptor/src/test/java/ru/yandex/qatools/allure/testng/testdata/TestDataClass.java
+++ b/allure-testng-adaptor/src/test/java/ru/yandex/qatools/allure/testng/testdata/TestDataClass.java
@@ -37,4 +37,8 @@ public class TestDataClass {
     public void parametrizedTest(int parameter) {
         assertThat(parameter, equalTo(2));
     }
+    
+    @Test(enabled = false, description = "This is pending test")
+    public void pendingTest() { 
+    }
 }


### PR DESCRIPTION
 TestNg have its own native description property which can be used instead of Allure @Description annotation @Test(description="This is description") but if @Description annotation is provided then it will override the native TestNg description property.
