### PR TITLE
Add support for native TestNg description

### DIFF
--- a/allure-testng-adaptor/src/main/java/ru/yandex/qatools/allure/testng/AllureTestListener.java
+++ b/allure-testng-adaptor/src/main/java/ru/yandex/qatools/allure/testng/AllureTestListener.java
@@ -17,6 +17,7 @@ import ru.yandex.qatools.allure.events.TestCasePendingEvent;
 import ru.yandex.qatools.allure.events.TestCaseStartedEvent;
 import ru.yandex.qatools.allure.events.TestSuiteFinishedEvent;
 import ru.yandex.qatools.allure.events.TestSuiteStartedEvent;
+import ru.yandex.qatools.allure.model.Description;
 import ru.yandex.qatools.allure.utils.AnnotationManager;
 
 import java.lang.annotation.Annotation;
@@ -86,7 +87,11 @@ public class AllureTestListener implements ITestListener, IConfigurationListener
     private void addPendingMethods(ITestContext iTestContext) {
         for (ITestNGMethod method: iTestContext.getExcludedMethods()) {
             if (method.isTest() && !method.getEnabled()) {
+                Description description = new Description().withValue(method.getDescription());
                 TestCaseStartedEvent event = new TestCaseStartedEvent(getSuiteUid(iTestContext), method.getMethodName());
+                if (description.getValue() != null) {
+                    event.setDescription(description);
+                }
                 AnnotationManager am = new AnnotationManager(method.getConstructorOrMethod().getMethod().getAnnotations());
                 am.setDefaults(method.getInstance().getClass().getAnnotations());
                 am.update(event);
@@ -108,7 +113,11 @@ public class AllureTestListener implements ITestListener, IConfigurationListener
         String testName = getName(iTestResult);
         startedTestNames.add(testName);
         testName = testName.replace(suitePrefix, "");
+        Description description = new Description().withValue(iTestResult.getMethod().getDescription());
         TestCaseStartedEvent event = new TestCaseStartedEvent(getSuiteUid(iTestResult.getTestContext()), testName);
+        if (description.getValue() != null) {
+            event.setDescription(description);
+        }
         AnnotationManager am = new AnnotationManager(getMethodAnnotations(iTestResult));
         am.setDefaults(getClassAnnotations(iTestResult));
         am.update(event);

--- a/allure-testng-adaptor/src/test/java/ru/yandex/qatools/allure/testng/AllureTestListenerMultipleSuitesTest.java
+++ b/allure-testng-adaptor/src/test/java/ru/yandex/qatools/allure/testng/AllureTestListenerMultipleSuitesTest.java
@@ -91,6 +91,7 @@ public class AllureTestListenerMultipleSuitesTest {
         TestCaseResult testResult = unmarshalledObject.getValue().getTestCases().get(0);
         
         assertThat(testResult.getStatus(), is(Status.PENDING));  
+        assertThat(testResult.getDescription().getValue(), is("This is pending test"));
     }
     
     private static void deleteNotEmptyDirectory(Path path) throws IOException {

--- a/allure-testng-adaptor/src/test/java/ru/yandex/qatools/allure/testng/AllureTestListenerTest.java
+++ b/allure-testng-adaptor/src/test/java/ru/yandex/qatools/allure/testng/AllureTestListenerTest.java
@@ -4,6 +4,7 @@ import org.junit.*;
 import org.mockito.InOrder;
 import org.testng.ISuite;
 import org.testng.ITestContext;
+import org.testng.ITestNGMethod;
 import org.testng.ITestResult;
 import org.testng.xml.XmlTest;
 
@@ -35,9 +36,9 @@ public class AllureTestListenerTest {
 
         testngListener.setLifecycle(allure);
         
-        ISuite suite=mock(ISuite.class);
+        ISuite suite = mock(ISuite.class);
     	when(suite.getName()).thenReturn(DEFAULT_SUITE_NAME);
-    	XmlTest xmlTest=mock(XmlTest.class);
+    	XmlTest xmlTest = mock(XmlTest.class);
     	when(xmlTest.getName()).thenReturn(DEFAULT_XML_TEST_NAME);
     	testContext = mock(ITestContext.class);
     	when(testContext.getSuite()).thenReturn(suite);
@@ -50,6 +51,9 @@ public class AllureTestListenerTest {
         when(testResult.getName()).thenReturn(DEFAULT_TEST_NAME);
         when(testResult.getTestContext()).thenReturn(testContext);
         doReturn(new Annotation[0]).when(testngListener).getMethodAnnotations(testResult);
+        ITestNGMethod method = mock(ITestNGMethod.class);
+        when(method.getDescription()).thenReturn(null);
+        when(testResult.getMethod()).thenReturn(method);
 
         testngListener.onTestSkipped(testResult);
 
@@ -64,6 +68,9 @@ public class AllureTestListenerTest {
         when(testResult.getTestContext()).thenReturn(testContext);
         when(testResult.getThrowable()).thenReturn(throwable);
         when(testResult.getName()).thenReturn(DEFAULT_TEST_NAME);
+        ITestNGMethod method = mock(ITestNGMethod.class);
+        when(method.getDescription()).thenReturn(null);
+        when(testResult.getMethod()).thenReturn(method);
         
         doReturn(new Annotation[0]).when(testngListener).getMethodAnnotations(testResult);
 
@@ -77,6 +84,9 @@ public class AllureTestListenerTest {
         ITestResult testResult = mock(ITestResult.class);
         when(testResult.getTestContext()).thenReturn(testContext);
         when(testResult.getName()).thenReturn(DEFAULT_TEST_NAME);
+        ITestNGMethod method = mock(ITestNGMethod.class);
+        when(method.getDescription()).thenReturn(null);
+        when(testResult.getMethod()).thenReturn(method);
         
         doReturn(new Annotation[0]).when(testngListener).getMethodAnnotations(testResult);
 
@@ -91,6 +101,9 @@ public class AllureTestListenerTest {
         when(testResult.getTestContext()).thenReturn(testContext);
         when(testResult.getThrowable()).thenReturn(new NullPointerException());
         when(testResult.getName()).thenReturn(DEFAULT_TEST_NAME);
+        ITestNGMethod method = mock(ITestNGMethod.class);
+        when(method.getDescription()).thenReturn(null);
+        when(testResult.getMethod()).thenReturn(method);
         
         doReturn(new Annotation[0]).when(testngListener).getMethodAnnotations(testResult);
 
@@ -110,6 +123,9 @@ public class AllureTestListenerTest {
         when(testResult.getTestContext()).thenReturn(testContext);
         when(testResult.getName()).thenReturn(DEFAULT_TEST_NAME);
         when(testResult.getParameters()).thenReturn(new Object[] { doubleParameter, stringParameter});
+        ITestNGMethod method = mock(ITestNGMethod.class);
+        when(method.getDescription()).thenReturn(null);
+        when(testResult.getMethod()).thenReturn(method);
         
         doReturn(new Annotation[0]).when(testngListener).getMethodAnnotations(testResult);
 

--- a/allure-testng-adaptor/src/test/java/ru/yandex/qatools/allure/testng/testdata/TestDataClass.java
+++ b/allure-testng-adaptor/src/test/java/ru/yandex/qatools/allure/testng/testdata/TestDataClass.java
@@ -38,7 +38,7 @@ public class TestDataClass {
         assertThat(parameter, equalTo(2));
     }
     
-    @Test(enabled = false)
+    @Test(enabled = false, description = "This is pending test")
     public void pendingTest(){ 
     }
 }


### PR DESCRIPTION
TestNg have its own native description property which can be used instead of Allure @Description annotation @Test(description="This is description") but if @Description annotation is provided then it will override the native TestNg description property.
