### PR TITLE
fix - use JVM name with thread id to unique identify thread

### DIFF
--- a/allure-java-adaptor-api/src/main/java/ru/yandex/qatools/allure/utils/AnnotationManager.java
+++ b/allure-java-adaptor-api/src/main/java/ru/yandex/qatools/allure/utils/AnnotationManager.java
@@ -13,6 +13,7 @@ import ru.yandex.qatools.allure.model.Label;
 import ru.yandex.qatools.allure.model.SeverityLevel;
 
 import java.lang.annotation.Annotation;
+import java.lang.management.ManagementFactory;
 import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -22,6 +23,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static java.lang.String.format;
 import static ru.yandex.qatools.allure.config.AllureModelUtils.createFeatureLabel;
 import static ru.yandex.qatools.allure.config.AllureModelUtils.createHostLabel;
 import static ru.yandex.qatools.allure.config.AllureModelUtils.createIssueLabel;
@@ -165,7 +167,11 @@ public class AnnotationManager {
             //create a default host if can't get current hostname
             event.getLabels().add(createHostLabel("default"));
         }
-        event.getLabels().add(createThreadLabel(Thread.currentThread().getName()));
+
+        event.getLabels().add(createThreadLabel(format("%s.%s",
+                ManagementFactory.getRuntimeMXBean().getName(),
+                Thread.currentThread().getName())
+        ));
         return event;
     }
 


### PR DESCRIPTION
Fixes #416 (maybe)

Related to answer in [StackOverflow](http://stackoverflow.com/questions/5583975/identify-the-current-jvm-with-java-or-jvmti?lq=1)
