### PR TITLE
add - sort threads in timeline tab by start time

### DIFF
--- a/allure-report-face/src/main/webapp/js/controllers.js
+++ b/allure-report-face/src/main/webapp/js/controllers.js
@@ -29,6 +29,19 @@ angular.module('allure.controllers', [])
         $scope.openTestcase = function(testcase) {
             $state.go('timeline.testcase', {testcaseUid: testcase.uid});
         };
+
+        data.hosts.forEach(function(host) {
+            host.threads.sort(function(thread1, thread2) {
+                var byTime= function(a, b) {
+                    return a.time.start - b.time.start;
+                };
+
+                var cases1 = thread1.testCases.sort(byTime),
+                    cases2 = thread2.testCases.sort(byTime);
+                return cases1[0].time.start - cases2[0].time.start;
+            });
+        });
+
         $scope.hosts = data.hosts;
         $scope.allCases = $scope.hosts.reduce(function(result, host) {
             return host.threads.reduce(function(result, thread) {


### PR DESCRIPTION
Now it sorts threads as in picture: 
![2014-10-19 18-52-50 4b9d2144-5616-11e4-9adb-3f26bc60b3a1 png 845x641](https://cloud.githubusercontent.com/assets/1964214/4693519/b3f9a3e0-579f-11e4-9e48-8cb044fdba36.png)

It seems that we should go back to previous view of timeline (but with hostnames separating feature)

`timeline.json` can be found on Gist (ask me)
