### PR TITLE
Solving concurrency problem

### DIFF
--- a/allure-java-adaptor-api/src/main/java/ru/yandex/qatools/allure/storages/StepStorage.java
+++ b/allure-java-adaptor-api/src/main/java/ru/yandex/qatools/allure/storages/StepStorage.java
@@ -15,6 +15,8 @@ import java.util.LinkedList;
  */
 public class StepStorage extends InheritableThreadLocal<Deque<Step>> {
 
+    private static final String ROOT_STEP_NAME = "Root step";
+
     /**
      * Returns the current thread's "initial value". Construct an new
      * {@link java.util.Deque} with root step {@link #createRootStep()}
@@ -25,6 +27,29 @@ public class StepStorage extends InheritableThreadLocal<Deque<Step>> {
     protected Deque<Step> initialValue() {
         Deque<Step> queue = new LinkedList<>();
         queue.add(createRootStep());
+        return queue;
+    }
+
+    /**
+     * In case parent thread spawns child threads it is necessary to provide
+     * a copy of step storage for each thread, because {@link #initialValue()}
+     * will be triggered only once.
+     *
+     * In case only root step is recorded, then it gets copied to work around the
+     * fact that there is ArrayList used for keeping track of sub steps.
+     *
+     * @param parentValue value from parent thread
+     * @return local copy for us in this thread
+     */
+    @Override
+    protected Deque<Step> childValue(Deque<Step> parentValue) {
+        LinkedList<Step> queue = new LinkedList<>();
+        if (parentValue.size() == 1
+                && ROOT_STEP_NAME.equals(parentValue.getFirst().getName())) {
+            queue.add(createRootStep());
+        } else {
+            queue.addAll(parentValue);
+        }
         return queue;
     }
 
@@ -69,7 +94,7 @@ public class StepStorage extends InheritableThreadLocal<Deque<Step>> {
      */
     public Step createRootStep() {
         return new Step()
-                .withName("Root step")
+                .withName(ROOT_STEP_NAME)
                 .withTitle("Allure step processing error: if you see this step something went wrong.")
                 .withStart(System.currentTimeMillis())
                 .withStatus(Status.BROKEN);


### PR DESCRIPTION
There is a concurrency bug when TestNG test spawns multiple threads, which in turn execute test steps in parallel. This happen due to the fact that value from InheritableThreadLocal is inherited and reference to non-synchronized LinkedList is passed to child threads. It could be fixed by creating a copy of LinkedList for every thread, so they are not out of sync.

There is a test reproducing this issues added.

This exception is thrown in case pull request is not applied.

```
java.util.NoSuchElementException
    at java.util.LinkedList.getLast(LinkedList.java:255)
    at ru.yandex.qatools.allure.storages.StepStorage.getLast(StepStorage.java:42)
    at ru.yandex.qatools.allure.Allure.fire(Allure.java:75)
```
