### PR TITLE
Add shutdown hook

### DIFF
--- a/allure-java-adaptor-api/src/main/java/ru/yandex/qatools/allure/storages/TestSuiteStorage.java
+++ b/allure-java-adaptor-api/src/main/java/ru/yandex/qatools/allure/storages/TestSuiteStorage.java
@@ -3,6 +3,7 @@ package ru.yandex.qatools.allure.storages;
 import ru.yandex.qatools.allure.model.TestSuiteResult;
 
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -38,7 +39,14 @@ public class TestSuiteStorage {
      *
      * @param uid to remove
      */
-    public void remove(String uid) {
-        testSuiteData.remove(uid);
+    public TestSuiteResult remove(String uid) {
+        return testSuiteData.remove(uid);
+    }
+
+    /**
+     * Return all started suites
+     */
+    public Set<Map.Entry<String, TestSuiteResult>> getStartedSuites() {
+        return testSuiteData.entrySet();
     }
 }

--- a/allure-java-adaptor-api/src/main/java/ru/yandex/qatools/allure/utils/AllureShutdownHook.java
+++ b/allure-java-adaptor-api/src/main/java/ru/yandex/qatools/allure/utils/AllureShutdownHook.java
@@ -1,0 +1,72 @@
+package ru.yandex.qatools.allure.utils;
+
+import ru.yandex.qatools.allure.Allure;
+import ru.yandex.qatools.allure.events.TestSuiteFinishedEvent;
+import ru.yandex.qatools.allure.model.Failure;
+import ru.yandex.qatools.allure.model.Status;
+import ru.yandex.qatools.allure.model.TestCaseResult;
+import ru.yandex.qatools.allure.model.TestSuiteResult;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * If test execution was interrupted this hook can help to save test data.
+ *
+ * @author Dmitry Baev charlie@yandex-team.ru
+ *         Date: 08.12.14
+ */
+public class AllureShutdownHook implements Runnable {
+
+    private final Set<Map.Entry<String, TestSuiteResult>> testSuites;
+
+    /**
+     * Create a new instance of shutdown hook.
+     */
+    public AllureShutdownHook(Set<Map.Entry<String, TestSuiteResult>> testSuites) {
+        this.testSuites = testSuites;
+    }
+
+    /**
+     * Mark unfinished test cases as interrupted for each unfinished test suite, then write
+     * test suite result
+     * @see #createFakeTestcaseWithWarning(ru.yandex.qatools.allure.model.TestSuiteResult)
+     * @see #markTestcaseAsInterruptedIfNotFinishedYet(ru.yandex.qatools.allure.model.TestCaseResult)
+     */
+    @Override
+    public void run() {
+        for (Map.Entry<String, TestSuiteResult> entry : testSuites) {
+            for (TestCaseResult testCase : entry.getValue().getTestCases()) {
+                markTestcaseAsInterruptedIfNotFinishedYet(testCase);
+            }
+            entry.getValue().getTestCases().add(createFakeTestcaseWithWarning(entry.getValue()));
+
+            Allure.LIFECYCLE.fire(new TestSuiteFinishedEvent(entry.getKey()));
+        }
+    }
+
+    /**
+     * Create fake test case, which will used for mark suite as interrupted.
+     */
+    public TestCaseResult createFakeTestcaseWithWarning(TestSuiteResult testSuite) {
+        return new TestCaseResult()
+                .withName(testSuite.getName())
+                .withTitle(testSuite.getName())
+                .withStart(testSuite.getStart())
+                .withStop(System.currentTimeMillis())
+                .withFailure(new Failure().withMessage("Test suite was interrupted, some test cases may be lost"))
+                .withStatus(Status.BROKEN);
+    }
+
+    /**
+     * If test not finished yet (in our case if stop time is zero) mark it as interrupted.
+     * Set message, stop time and status.
+     */
+    public void markTestcaseAsInterruptedIfNotFinishedYet(TestCaseResult testCase) {
+        if (testCase.getStop() == 0L) {
+            testCase.setStop(System.currentTimeMillis());
+            testCase.setStatus(Status.BROKEN);
+            testCase.setFailure(new Failure().withMessage("Test was interrupted"));
+        }
+    }
+}

--- a/allure-java-adaptor-api/src/test/java/ru/yandex/qatools/allure/ListenersNotifierTest.java
+++ b/allure-java-adaptor-api/src/test/java/ru/yandex/qatools/allure/ListenersNotifierTest.java
@@ -14,6 +14,7 @@ import ru.yandex.qatools.allure.events.TestCaseFinishedEvent;
 import ru.yandex.qatools.allure.events.TestCaseStartedEvent;
 import ru.yandex.qatools.allure.events.TestSuiteEvent;
 import ru.yandex.qatools.allure.events.TestSuiteFinishedEvent;
+import ru.yandex.qatools.allure.events.TestSuiteStartedEvent;
 import ru.yandex.qatools.allure.experimental.testdata.SimpleListener;
 import ru.yandex.qatools.allure.model.Step;
 import ru.yandex.qatools.allure.model.TestCaseResult;
@@ -110,7 +111,8 @@ public class ListenersNotifierTest {
 
     @Test
     public void testsuiteFinishedEventTest() throws Exception {
-        allure.fire(new TestSuiteFinishedEvent(""));
+        allure.fire(new TestSuiteStartedEvent("uid", "name"));
+        allure.fire(new TestSuiteFinishedEvent("uid"));
         assertThat(listener.get(SimpleListener.EventType.TESTSUITE_FINISHED_EVENT), is(1));
     }
 


### PR DESCRIPTION
Fixes #444 

For each interrupted test suite:
- mark each unfinished test case (but started) as broken with message `Test was interrupted` ![2014-12-08 16 38 31](https://cloud.githubusercontent.com/assets/2149631/5340033/c88b58b4-7ef8-11e4-9967-4c869a5e640d.png)
- add for each unfinished (but started) test suite warning `Test suite was interrupted, some test cases may be lost` (using fake broken test case) ![2014-12-08 16 38 19](https://cloud.githubusercontent.com/assets/2149631/5340030/c48ab62e-7ef8-11e4-986c-04ed9be544a5.png)
- write test suite results as usual 

but we **still lose info** about:
- all step & attachment data from interrupted test cases
- unstarted test case
- unstarted test suites
