### PR TITLE
Ordering built-in and custom data providers (#414)

### DIFF
--- a/allure-report-data/pom.xml
+++ b/allure-report-data/pom.xml
@@ -141,6 +141,11 @@
 
         <!--Testing-->
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/allure-report-data/src/main/java/ru/yandex/qatools/allure/data/AllureReportGenerator.java
+++ b/allure-report-data/src/main/java/ru/yandex/qatools/allure/data/AllureReportGenerator.java
@@ -4,12 +4,12 @@ import ru.yandex.qatools.allure.data.providers.DataProvider;
 import ru.yandex.qatools.allure.data.utils.Async;
 
 import java.io.File;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
-import static ru.yandex.qatools.allure.data.utils.AllureReportUtils.createDirectory;
-import static ru.yandex.qatools.allure.data.utils.AllureReportUtils.deleteFile;
-import static ru.yandex.qatools.allure.data.utils.AllureReportUtils.writeAllureReportInfo;
+import static ru.yandex.qatools.allure.data.utils.AllureReportUtils.*;
 import static ru.yandex.qatools.allure.data.utils.ServiceLoaderUtils.load;
 
 
@@ -53,6 +53,7 @@ public class AllureReportGenerator {
         final File testRun = testRunGenerator.generate();
 
         List<DataProvider> dataProviders = load(getClassLoader(), DataProvider.class);
+        Collections.sort(dataProviders, new DataProviderComparator());
 
         new Async<DataProvider>() {
             @Override
@@ -85,4 +86,14 @@ public class AllureReportGenerator {
     public File[] getInputDirectories() {
         return inputDirectories;
     }
+
+    protected static class DataProviderComparator implements Comparator<DataProvider> {
+
+        @Override
+        public int compare(DataProvider dp1, DataProvider dp2) {
+            return dp1.getPhase().compareTo(dp2.getPhase());
+        }
+
+    }
+
 }

--- a/allure-report-data/src/main/java/ru/yandex/qatools/allure/data/providers/AbstractDataProvider.java
+++ b/allure-report-data/src/main/java/ru/yandex/qatools/allure/data/providers/AbstractDataProvider.java
@@ -35,6 +35,11 @@ public abstract class AbstractDataProvider implements DataProvider {
         }
     }
 
+    @Override
+    public DataProviderPhase getPhase() {
+        return DataProviderPhase.DEFAULT;
+    }
+
     protected long serialize(File outputDirectory, File body) throws IOException {
         try (Reader reader = new FileReader(body)) {
             return serialize(outputDirectory, getType(), getJsonFileName(), reader);

--- a/allure-report-data/src/main/java/ru/yandex/qatools/allure/data/providers/AttachmentsProvider.java
+++ b/allure-report-data/src/main/java/ru/yandex/qatools/allure/data/providers/AttachmentsProvider.java
@@ -36,6 +36,11 @@ public class AttachmentsProvider implements DataProvider {
         return size;
     }
 
+    @Override
+    public DataProviderPhase getPhase() {
+        return DataProviderPhase.DEFAULT;
+    }
+
     /**
      * Copies a file to a new location preserving the file date using
      * {@link org.apache.commons.io.FileUtils#copyFile(java.io.File, java.io.File)}

--- a/allure-report-data/src/main/java/ru/yandex/qatools/allure/data/providers/DataProvider.java
+++ b/allure-report-data/src/main/java/ru/yandex/qatools/allure/data/providers/DataProvider.java
@@ -21,4 +21,12 @@ public interface DataProvider {
      */
     long provide(File testPack, File[] inputDirectories, File outputDirectory);
 
+    /**
+     * Provide phase in which data provider will be executed.
+     * Please see {@link DataProviderPhase} for possible values.
+     *
+     * @return ordering number
+     */
+    DataProviderPhase getPhase();
+
 }

--- a/allure-report-data/src/main/java/ru/yandex/qatools/allure/data/providers/DataProviderPhase.java
+++ b/allure-report-data/src/main/java/ru/yandex/qatools/allure/data/providers/DataProviderPhase.java
@@ -1,0 +1,11 @@
+package ru.yandex.qatools.allure.data.providers;
+
+/**
+ * @author Mihails Volkovs
+ *         Date: 10.12.14
+ */
+public enum DataProviderPhase {
+
+    PRE_PROCESS, DEFAULT, POST_PROCESS
+
+}

--- a/allure-report-data/src/test/java/ru/yandex/qatools/allure/data/DataProviderComparatorTest.java
+++ b/allure-report-data/src/test/java/ru/yandex/qatools/allure/data/DataProviderComparatorTest.java
@@ -1,0 +1,50 @@
+package ru.yandex.qatools.allure.data;
+
+import org.junit.Before;
+import org.junit.Test;
+import ru.yandex.qatools.allure.data.providers.DataProvider;
+import ru.yandex.qatools.allure.data.providers.DataProviderPhase;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static junit.framework.TestCase.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static ru.yandex.qatools.allure.data.AllureReportGenerator.DataProviderComparator;
+import static ru.yandex.qatools.allure.data.providers.DataProviderPhase.*;
+
+/**
+ * @author Mihails Volkovs
+ *         Date: 12/12/14
+ */
+public class DataProviderComparatorTest {
+
+    private DataProviderComparator comparator;
+    private List<DataProvider> providers;
+
+    @Before
+    public void setUp() {
+        comparator = new DataProviderComparator();
+        providers = newArrayList(create(DEFAULT), create(POST_PROCESS), create(PRE_PROCESS));
+    }
+
+    @Test
+    public void compare() {
+        Collections.sort(providers, comparator);
+
+        Iterator<DataProvider> iterator = providers.iterator();
+        assertEquals(PRE_PROCESS, iterator.next().getPhase());
+        assertEquals(DEFAULT, iterator.next().getPhase());
+        assertEquals(POST_PROCESS, iterator.next().getPhase());
+    }
+
+    private DataProvider create(DataProviderPhase phase) {
+        DataProvider dataProvider = mock(DataProvider.class);
+        when(dataProvider.getPhase()).thenReturn(phase);
+        return dataProvider;
+    }
+
+}


### PR DESCRIPTION
So custom data providers could be executed after built-in data providers. This will allow not only create additional resources, but also update resources (already) generated by Allure standard data providers.

I didn't want to add explicit ordering in data providers. Data provider dependency management is also an overkill IMO. So, there are minimal changes to add ordering required.

Thoughts?