### PR TITLE
Truncate testcase.name on ui side

### DIFF
--- a/allure-report-face/src/main/webapp/js/charts/duration.js
+++ b/allure-report-face/src/main/webapp/js/charts/duration.js
@@ -70,7 +70,7 @@ angular.module('allure.charts.duration', ['allure.charts.util']).directive('dura
 
         this.tooltip = new d3Tooltip(bars,
             '<div><strong><span>{{ \'graph.CASES\' | translate:"{ amount: testcases.length }":"messageformat" }}</span> {{status | lowercase}}</strong></div>' +
-                '<ul><li ng-repeat="testcase in testcases | limitTo:10" title="testcase.name">{{testcase.name | truncate}}</li></ul>' +
+                '<ul><li ng-repeat="testcase in testcases | limitTo:10" title="{{testcase.name}}">{{testcase.name | truncate}}</li></ul>' +
                 '<div ng-if="testcases.length > 10"><i>and {{testcases.length-10}} more</i></div>',
             {tooltipCls: 'd3-tooltip d3-tooltip-list'}
         );

--- a/allure-report-face/src/main/webapp/js/charts/duration.js
+++ b/allure-report-face/src/main/webapp/js/charts/duration.js
@@ -70,7 +70,7 @@ angular.module('allure.charts.duration', ['allure.charts.util']).directive('dura
 
         this.tooltip = new d3Tooltip(bars,
             '<div><strong><span>{{ \'graph.CASES\' | translate:"{ amount: testcases.length }":"messageformat" }}</span> {{status | lowercase}}</strong></div>' +
-                '<ul><li ng-repeat="testcase in testcases | limitTo:10">{{testcase.title}}</li></ul>' +
+                '<ul><li ng-repeat="testcase in testcases | limitTo:10" title="testcase.name">{{testcase.name | truncate}}</li></ul>' +
                 '<div ng-if="testcases.length > 10"><i>and {{testcases.length-10}} more</i></div>',
             {tooltipCls: 'd3-tooltip d3-tooltip-list'}
         );

--- a/allure-report-face/src/main/webapp/js/charts/severityMap.js
+++ b/allure-report-face/src/main/webapp/js/charts/severityMap.js
@@ -64,7 +64,7 @@ angular.module('allure.charts.severityMap', ['allure.charts.util']).directive('s
 
         this.tooltip = new d3Tooltip(this.bars.selectAll('.bar'),
             '<div><strong><span>{{ \'graph.CASES\' | translate:"{ amount: testcases.length }":"messageformat" }}</span> {{status | lowercase | translate}}</strong></div>' +
-                '<ul><li ng-repeat="testcase in testcases | limitTo:10">{{testcase.title}}</li></ul>' +
+                '<ul><li ng-repeat="testcase in testcases | limitTo:10" title="testcase.name">{{testcase.name | truncate}}</li></ul>' +
                 '<div ng-if="testcases.length > 10"><i>and {{testcases.length-10}} more</i></div>',
             {tooltipCls: 'd3-tooltip d3-tooltip-list'}
         );

--- a/allure-report-face/src/main/webapp/js/charts/severityMap.js
+++ b/allure-report-face/src/main/webapp/js/charts/severityMap.js
@@ -64,7 +64,7 @@ angular.module('allure.charts.severityMap', ['allure.charts.util']).directive('s
 
         this.tooltip = new d3Tooltip(this.bars.selectAll('.bar'),
             '<div><strong><span>{{ \'graph.CASES\' | translate:"{ amount: testcases.length }":"messageformat" }}</span> {{status | lowercase | translate}}</strong></div>' +
-                '<ul><li ng-repeat="testcase in testcases | limitTo:10" title="testcase.name">{{testcase.name | truncate}}</li></ul>' +
+                '<ul><li ng-repeat="testcase in testcases | limitTo:10" title="{{testcase.name}}">{{testcase.name | truncate}}</li></ul>' +
                 '<div ng-if="testcases.length > 10"><i>and {{testcases.length-10}} more</i></div>',
             {tooltipCls: 'd3-tooltip d3-tooltip-list'}
         );

--- a/allure-report-face/src/main/webapp/js/filters.js
+++ b/allure-report-face/src/main/webapp/js/filters.js
@@ -87,4 +87,24 @@ angular.module('allure.filters', [])
         return function(value) {
             return $sce.trustAsHtml(''+value);
         };
-    }]);
+    }])
+    .filter('truncate', function () {
+        return function (text, length, end) {
+            if (text === undefined) {
+                return;
+            }
+            if (isNaN(length))
+                length = 122;
+
+            if (end === undefined)
+                end = "...";
+
+            if (text.length <= length || text.length - end.length <= length) {
+                return text;
+            }
+            else {
+                return String(text).substring(0, length - end.length) + end;
+            }
+
+        };
+    });

--- a/allure-report-face/src/main/webapp/templates/testcase/list.html
+++ b/allure-report-face/src/main/webapp/templates/testcase/list.html
@@ -4,8 +4,8 @@
         <tbody>
         <tr ng-repeat="testcase in list.items" class="clickable" ng-click="selectTestcase(testcase)" ng-class="{active:testcase.uid==selectedUid}">
             <td allure-table-col="{heading:'#', predicate: 'order', flex: 0.5}">{{testcase.order}}</td>
-            <td allure-table-col="{heading:'Title', predicate: 'title', flex: 3}" class="line-ellipsis" title="{{testcase.title}}">
-                {{testcase.title}}
+            <td allure-table-col="{heading:'Title', predicate: 'title', flex: 3}" class="line-ellipsis" title="{{testcase.name}}">
+                {{testcase.name | truncate}}
             </td>
             <td allure-table-col="{heading:'Duration', predicate: 'time.duration', class:'text-right', flex: 1.5, reverse: true}"  class="line-ellipsis text-right" title="{{testcase.time.duration | time}}">
                 {{testcase.time.duration | time}}

--- a/allure-report-face/src/main/webapp/templates/testcase/testcase.html
+++ b/allure-report-face/src/main/webapp/templates/testcase/testcase.html
@@ -2,14 +2,14 @@
     {{'testcase.TESTCASE' | translate}}<span ng-show="testcase.name" class="text-muted">: {{testcase.name}} <copy-button text="testcase.name"></copy-button></span>
 </div>
 <div class="pane__header title-status-{{testcase.status | lowercase}}">
-    <h3>
+    <h3 title="testcase.name">
         <div class="pane__header_controls pull-right">
             <span class="fa fa-expand clickable" tooltip="{{'tooltip.EXPAND' | translate}}" ng-hide="isState('testcase.expanded')" ng-click="go('testcase.expanded')"></span>
             <span class="fa fa-compress clickable" tooltip="{{'tooltip.COLLAPSE' | translate}}" ng-show="isState('testcase.expanded')" ng-click="go('testcase')"></span>
             <span class="fa fa-close clickable" tooltip="{{'tooltip.CLOSE' | translate}}" ng-click="closeTestcase()"></span>
         </div>
         <span class="icon-status-{{testcase.status | lowercase}}"></span>
-        {{testcase.title}}
+        {{testcase.name | truncate}}
         <small translate="testcase.SEVERITY" translate-value-severity="{{testcase.severity | translate}}"></small>
     </h3>
     <div class="external-system-references">

--- a/allure-report-face/src/main/webapp/templates/testcase/testcase.html
+++ b/allure-report-face/src/main/webapp/templates/testcase/testcase.html
@@ -2,7 +2,7 @@
     {{'testcase.TESTCASE' | translate}}<span ng-show="testcase.name" class="text-muted">: {{testcase.name}} <copy-button text="testcase.name"></copy-button></span>
 </div>
 <div class="pane__header title-status-{{testcase.status | lowercase}}">
-    <h3 title="testcase.name">
+    <h3 title="{{testcase.name}}">
         <div class="pane__header_controls pull-right">
             <span class="fa fa-expand clickable" tooltip="{{'tooltip.EXPAND' | translate}}" ng-hide="isState('testcase.expanded')" ng-click="go('testcase.expanded')"></span>
             <span class="fa fa-compress clickable" tooltip="{{'tooltip.COLLAPSE' | translate}}" ng-show="isState('testcase.expanded')" ng-click="go('testcase')"></span>


### PR DESCRIPTION
As discussed in #408 - there is the first step: Removing testcase.title from ui and truncate testcase.name instead.
I was set default length to 122 and default endings to "...". Anyway it can be overriden in filter params.