### PR TITLE
change Allure suite name format (fixes #492)

### DIFF
--- a/allure-testng-adaptor/src/main/java/ru/yandex/qatools/allure/testng/AllureTestListener.java
+++ b/allure-testng-adaptor/src/main/java/ru/yandex/qatools/allure/testng/AllureTestListener.java
@@ -73,7 +73,7 @@ public class AllureTestListener implements ITestListener, IConfigurationListener
     @Override
     public void onStart(ITestContext iTestContext) {
         getLifecycle().fire(new TestSuiteStartedEvent(
-                getSuiteUid(iTestContext), iTestContext.getSuite().getName()
+                getSuiteUid(iTestContext), getCurrentSuiteTitle(iTestContext)
         ).withTitle(
                 getCurrentSuiteTitle(iTestContext)
         ).withLabels(


### PR DESCRIPTION
change Allure suite name format from `<testng-suite>` to `<testng-suite> : <testng-xml-test>`
