### PR TITLE
Automatically attaching logs to according test steps (#420)

### DIFF
--- a/allure-java-aspects/pom.xml
+++ b/allure-java-aspects/pom.xml
@@ -31,6 +31,10 @@
             <artifactId>junit</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
         </dependency>

--- a/allure-java-aspects/src/main/java/ru/yandex/qatools/allure/aspects/AllureStepsAspects.java
+++ b/allure-java-aspects/src/main/java/ru/yandex/qatools/allure/aspects/AllureStepsAspects.java
@@ -1,17 +1,15 @@
 package ru.yandex.qatools.allure.aspects;
 
 import org.aspectj.lang.JoinPoint;
-import org.aspectj.lang.annotation.AfterReturning;
-import org.aspectj.lang.annotation.AfterThrowing;
-import org.aspectj.lang.annotation.Aspect;
-import org.aspectj.lang.annotation.Before;
-import org.aspectj.lang.annotation.Pointcut;
+import org.aspectj.lang.annotation.*;
 import org.aspectj.lang.reflect.MethodSignature;
 import ru.yandex.qatools.allure.Allure;
 import ru.yandex.qatools.allure.annotations.Step;
 import ru.yandex.qatools.allure.events.StepFailureEvent;
 import ru.yandex.qatools.allure.events.StepFinishedEvent;
 import ru.yandex.qatools.allure.events.StepStartedEvent;
+import ru.yandex.qatools.allure.logging.Attachments;
+import ru.yandex.qatools.allure.logging.TestStepLogs;
 
 import static ru.yandex.qatools.allure.aspects.AllureAspectUtils.getName;
 import static ru.yandex.qatools.allure.aspects.AllureAspectUtils.getTitle;
@@ -48,18 +46,23 @@ public class AllureStepsAspects {
         if (!stepTitle.isEmpty()) {
             startedEvent.setTitle(stepTitle);
         }
-
+        TestStepLogs.addLog();
         ALLURE.fire(startedEvent);
     }
 
     @AfterThrowing(pointcut = "anyMethod() && withStepAnnotation()", throwing = "e")
     public void stepFailed(JoinPoint joinPoint, Throwable e) {
         ALLURE.fire(new StepFailureEvent().withThrowable(e));
-        ALLURE.fire(new StepFinishedEvent());
+        finishStep();
     }
 
     @AfterReturning(pointcut = "anyMethod() && withStepAnnotation()", returning = "result")
     public void stepStop(JoinPoint joinPoint, Object result) {
+        finishStep();
+    }
+
+    private void finishStep() {
+        Attachments.addLogAttachment();
         ALLURE.fire(new StepFinishedEvent());
     }
 

--- a/allure-java-aspects/src/main/java/ru/yandex/qatools/allure/logging/Attachments.java
+++ b/allure-java-aspects/src/main/java/ru/yandex/qatools/allure/logging/Attachments.java
@@ -1,0 +1,21 @@
+package ru.yandex.qatools.allure.logging;
+
+import ru.yandex.qatools.allure.Allure;
+import ru.yandex.qatools.allure.config.AllureConfig;
+import ru.yandex.qatools.allure.events.MakeAttachmentEvent;
+
+/**
+ * Created by Mihails Volkovs on 2015.03.06.
+ */
+public class Attachments {
+
+    private static AllureConfig allureConfig = AllureConfig.newInstance();
+
+    public static void addLogAttachment() {
+        String attachment = TestStepLogs.removeLog();
+        if (!"".equals(attachment)) {
+            Allure allure = Allure.LIFECYCLE;
+            allure.fire(new MakeAttachmentEvent(attachment.getBytes(allureConfig.getAttachmentsEncoding()), "log.txt", "text/plain"));
+        }
+    }
+}

--- a/allure-java-aspects/src/main/java/ru/yandex/qatools/allure/logging/PrintStreamSplitter.java
+++ b/allure-java-aspects/src/main/java/ru/yandex/qatools/allure/logging/PrintStreamSplitter.java
@@ -1,0 +1,36 @@
+package ru.yandex.qatools.allure.logging;
+
+
+import ru.yandex.qatools.allure.logging.external.TeeOutputStream;
+
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.nio.charset.Charset;
+
+/**
+ * PrintStream writing into two streams.
+ * Created by Mihails Volkovs on 2015.03.05.
+ */
+public class PrintStreamSplitter extends PrintStream {
+
+    private ByteArrayOutputStream content;
+
+    public PrintStreamSplitter(OutputStream branch) {
+        this(new ByteArrayOutputStream(), branch);
+    }
+
+    public PrintStreamSplitter(ByteArrayOutputStream out, OutputStream branch) {
+        super(new TeeOutputStream(out, branch));
+        content = out;
+    }
+
+    public PrintStreamSplitter(OutputStream out, OutputStream branch) {
+        super(new TeeOutputStream(out, branch));
+        content = new ByteArrayOutputStream();
+    }
+
+    public String toContent() {
+        return new String(content.toByteArray(), Charset.forName("utf-8"));
+    }
+}

--- a/allure-java-aspects/src/main/java/ru/yandex/qatools/allure/logging/StandardOutputSetter.java
+++ b/allure-java-aspects/src/main/java/ru/yandex/qatools/allure/logging/StandardOutputSetter.java
@@ -1,0 +1,29 @@
+package ru.yandex.qatools.allure.logging;
+
+import java.io.PrintStream;
+
+/**
+ * Created by Mihails Volkovs on 2015.03.05.
+ */
+public class StandardOutputSetter {
+
+    private static PrintStream standardOutput = System.out;
+
+    private static PrintStream standardError = System.err;
+
+    public static void set() {
+
+        // 3-rd party friendly
+        standardOutput = System.out;
+        standardError = System.err;
+
+        System.setOut(new PrintStreamSplitter(standardOutput, new PrintStream(TestStepLogs.INSTANCE)));
+        System.setErr(new PrintStreamSplitter(standardError, new PrintStream(TestStepLogs.INSTANCE)));
+    }
+
+    public static void reset() {
+        System.setOut(standardOutput);
+        System.setErr(standardError);
+    }
+
+}

--- a/allure-java-aspects/src/main/java/ru/yandex/qatools/allure/logging/TestStepLogs.java
+++ b/allure-java-aspects/src/main/java/ru/yandex/qatools/allure/logging/TestStepLogs.java
@@ -1,0 +1,62 @@
+package ru.yandex.qatools.allure.logging;
+
+import ru.yandex.qatools.allure.logging.external.NullOutputStream;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.util.Stack;
+
+/**
+ * Created by Mihails Volkovs on 2015.03.05.
+ */
+public class TestStepLogs extends OutputStream {
+
+    public static final TestStepLogs INSTANCE = new TestStepLogs();
+
+    private static StackThreadLocal printStreams = new StackThreadLocal();
+
+    private TestStepLogs() {
+        // hiding constructor
+    }
+
+    public static void addLog() {
+        PrintStream printStream = getPrintStream();
+        printStreams.get().push(new PrintStreamSplitter(printStream));
+    }
+
+    public static String removeLog() {
+        Stack<PrintStreamSplitter> stack = getStack();
+        if (!stack.isEmpty()) {
+            PrintStreamSplitter printStream = stack.pop();
+            return printStream.toContent();
+        }
+        return "";
+    }
+
+    private static PrintStream getPrintStream() {
+        Stack<PrintStreamSplitter> stack = printStreams.get();
+        if (stack.isEmpty()) {
+            return new PrintStream(new NullOutputStream());
+        }
+        return stack.peek();
+    }
+
+    private static Stack<PrintStreamSplitter> getStack() {
+        return printStreams.get();
+    }
+
+    @Override
+    public void write(int i) throws IOException {
+        getPrintStream().write(i);
+    }
+
+    private static class StackThreadLocal extends ThreadLocal<Stack<PrintStreamSplitter>> {
+
+        @Override
+        protected Stack<PrintStreamSplitter> initialValue() {
+            return new Stack<PrintStreamSplitter>();
+        }
+    }
+
+}

--- a/allure-java-aspects/src/main/java/ru/yandex/qatools/allure/logging/external/NullOutputStream.java
+++ b/allure-java-aspects/src/main/java/ru/yandex/qatools/allure/logging/external/NullOutputStream.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ru.yandex.qatools.allure.logging.external;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * This OutputStream writes all data to the famous <b>/dev/null</b>.
+ * <p/>
+ * This output stream has no destination (file/socket etc.) and all
+ * bytes written to it are ignored and lost.
+ *
+ * @version $Id: NullOutputStream.java 1471767 2013-04-24 23:24:19Z sebb $
+ */
+public class NullOutputStream extends OutputStream {
+
+    /**
+     * A singleton.
+     */
+    public static final NullOutputStream NULL_OUTPUT_STREAM = new NullOutputStream();
+
+    /**
+     * Does nothing - output to <code>/dev/null</code>.
+     *
+     * @param b   The bytes to write
+     * @param off The start offset
+     * @param len The number of bytes to write
+     */
+    @Override
+    public void write(final byte[] b, final int off, final int len) {
+        //to /dev/null
+    }
+
+    /**
+     * Does nothing - output to <code>/dev/null</code>.
+     *
+     * @param b The byte to write
+     */
+    @Override
+    public void write(final int b) {
+        //to /dev/null
+    }
+
+    /**
+     * Does nothing - output to <code>/dev/null</code>.
+     *
+     * @param b The bytes to write
+     * @throws IOException never
+     */
+    @Override
+    public void write(final byte[] b) throws IOException {
+        //to /dev/null
+    }
+
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/allure-java-aspects/src/main/java/ru/yandex/qatools/allure/logging/external/ProxyOutputStream.java
+++ b/allure-java-aspects/src/main/java/ru/yandex/qatools/allure/logging/external/ProxyOutputStream.java
@@ -1,0 +1,234 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ru.yandex.qatools.allure.logging.external;
+
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * A Proxy stream which acts as expected, that is it passes the method
+ * calls on to the proxied stream and doesn't change which methods are
+ * being called. It is an alternative base class to FilterOutputStream
+ * to increase reusability.
+ * <p/>
+ * See the protected methods for ways in which a subclass can easily decorate
+ * a stream with custom pre-, post- or error processing functionality.
+ *
+ * @version $Id: ProxyOutputStream.java 1415850 2012-11-30 20:51:39Z ggregory $
+ */
+public class ProxyOutputStream extends FilterOutputStream {
+
+    /**
+     * Constructs a new ProxyOutputStream.
+     *
+     * @param proxy the OutputStream to delegate to
+     */
+    public ProxyOutputStream(final OutputStream proxy) {
+        super(proxy);
+        // the proxy is stored in a protected superclass variable named 'out'
+    }
+
+    /**
+     * Invokes the delegate's <code>write(int)</code> method.
+     *
+     * @param idx the byte to write
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public void write(final int idx) throws IOException {
+        try {
+            beforeWrite(1);
+            out.write(idx);
+            afterWrite(1);
+        } catch (final IOException e) {
+            handleIOException(e);
+        }
+    }
+
+    /**
+     * Invokes the delegate's <code>write(byte[])</code> method.
+     *
+     * @param bts the bytes to write
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public void write(final byte[] bts) throws IOException {
+        try {
+            final int len = bts != null ? bts.length : 0;
+            beforeWrite(len);
+            out.write(bts);
+            afterWrite(len);
+        } catch (final IOException e) {
+            handleIOException(e);
+        }
+    }
+
+    /**
+     * Invokes the delegate's <code>write(byte[])</code> method.
+     *
+     * @param bts the bytes to write
+     * @param st  The start offset
+     * @param end The number of bytes to write
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public void write(final byte[] bts, final int st, final int end) throws IOException {
+        try {
+            beforeWrite(end);
+            out.write(bts, st, end);
+            afterWrite(end);
+        } catch (final IOException e) {
+            handleIOException(e);
+        }
+    }
+
+    /**
+     * Invokes the delegate's <code>flush()</code> method.
+     *
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public void flush() throws IOException {
+        try {
+            out.flush();
+        } catch (final IOException e) {
+            handleIOException(e);
+        }
+    }
+
+    /**
+     * Invokes the delegate's <code>close()</code> method.
+     *
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public void close() throws IOException {
+        try {
+            out.close();
+        } catch (final IOException e) {
+            handleIOException(e);
+        }
+    }
+
+    /**
+     * Invoked by the write methods before the call is proxied. The number
+     * of bytes to be written (1 for the {@link #write(int)} method, buffer
+     * length for {@link #write(byte[])}, etc.) is given as an argument.
+     * <p/>
+     * Subclasses can override this method to add common pre-processing
+     * functionality without having to override all the write methods.
+     * The default implementation does nothing.
+     *
+     * @param n number of bytes to be written
+     * @throws IOException if the pre-processing fails
+     * @since 2.0
+     */
+    protected void beforeWrite(final int n) throws IOException {
+    }
+
+    /**
+     * Invoked by the write methods after the proxied call has returned
+     * successfully. The number of bytes written (1 for the
+     * {@link #write(int)} method, buffer length for {@link #write(byte[])},
+     * etc.) is given as an argument.
+     * <p/>
+     * Subclasses can override this method to add common post-processing
+     * functionality without having to override all the write methods.
+     * The default implementation does nothing.
+     *
+     * @param n number of bytes written
+     * @throws IOException if the post-processing fails
+     * @since 2.0
+     */
+    protected void afterWrite(final int n) throws IOException {
+    }
+
+    /**
+     * Handle any IOExceptions thrown.
+     * <p/>
+     * This method provides a point to implement custom exception
+     * handling. The default behaviour is to re-throw the exception.
+     *
+     * @param e The IOException thrown
+     * @throws IOException if an I/O error occurs
+     * @since 2.0
+     */
+    protected void handleIOException(final IOException e) throws IOException {
+        throw e;
+    }
+
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/allure-java-aspects/src/main/java/ru/yandex/qatools/allure/logging/external/TeeOutputStream.java
+++ b/allure-java-aspects/src/main/java/ru/yandex/qatools/allure/logging/external/TeeOutputStream.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ru.yandex.qatools.allure.logging.external;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * Classic splitter of OutputStream. Named after the unix 'tee' 
+ * command. It allows a stream to be branched off so there 
+ * are now two streams.
+ *
+ * @version $Id: TeeOutputStream.java 1415850 2012-11-30 20:51:39Z ggregory $
+ */
+public class TeeOutputStream extends ProxyOutputStream {
+
+    /** the second OutputStream to write to */
+    protected OutputStream branch;
+
+    /**
+     * Constructs a TeeOutputStream.
+     * @param out the main OutputStream
+     * @param branch the second OutputStream
+     */
+    public TeeOutputStream(final OutputStream out, final OutputStream branch) {
+        super(out);
+        this.branch = branch;
+    }
+
+    /**
+     * Write the bytes to both streams.
+     * @param b the bytes to write
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public synchronized void write(final byte[] b) throws IOException {
+        super.write(b);
+        this.branch.write(b);
+    }
+
+    /**
+     * Write the specified bytes to both streams.
+     * @param b the bytes to write
+     * @param off The start offset
+     * @param len The number of bytes to write
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public synchronized void write(final byte[] b, final int off, final int len) throws IOException {
+        super.write(b, off, len);
+        this.branch.write(b, off, len);
+    }
+
+    /**
+     * Write a byte to both streams.
+     * @param b the byte to write
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public synchronized void write(final int b) throws IOException {
+        super.write(b);
+        this.branch.write(b);
+    }
+
+    /**
+     * Flushes both streams.
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public void flush() throws IOException {
+        super.flush();
+        this.branch.flush();
+    }
+
+    /**
+     * Closes both output streams.
+     *
+     * If closing the main output stream throws an exception, attempt to close the branch output stream.
+     *
+     * If closing the main and branch output streams both throw exceptions, which exceptions is thrown by this method is
+     * currently unspecified and subject to change.
+     *
+     * @throws IOException
+     *             if an I/O error occurs
+     */
+    @Override
+    public void close() throws IOException {
+        try {
+            super.close();
+        } finally {
+            this.branch.close();
+        }
+    }
+
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/allure-java-aspects/src/test/java/ru/yandex/qatools/allure/logging/StandardOutputSetterTest.java
+++ b/allure-java-aspects/src/test/java/ru/yandex/qatools/allure/logging/StandardOutputSetterTest.java
@@ -1,0 +1,71 @@
+package ru.yandex.qatools.allure.logging;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import ru.yandex.qatools.allure.logging.external.NullOutputStream;
+
+import java.io.PrintStream;
+
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+
+public class StandardOutputSetterTest {
+
+    private PrintStream standardOutput;
+
+    private PrintStream standardError;
+
+    @Before
+    public void setUp() {
+        standardOutput = System.out;
+        standardError = System.err;
+    }
+
+    @After
+    public void tearDown() {
+        System.setOut(standardOutput);
+        System.setErr(standardError);
+    }
+
+
+    @Test
+    public void set() {
+        assertSame(standardOutput, System.out);
+        assertSame(standardError, System.err);
+
+        StandardOutputSetter.set();
+        assertNotSame(standardOutput, System.out);
+        assertNotSame(standardError, System.err);
+
+        StandardOutputSetter.reset();
+        assertSame(standardOutput, System.out);
+        assertSame(standardError, System.err);
+    }
+
+    @Test
+    public void resetNotSet() {
+        StandardOutputSetter.reset();
+        assertSame(standardOutput, System.out);
+        assertSame(standardError, System.err);
+    }
+
+    @Test
+    public void thirdPartySetterFriendly() {
+
+        // simulating third party
+        PrintStream legalOut = new PrintStream(new NullOutputStream());
+        PrintStream legalErr = new PrintStream(new NullOutputStream());
+        System.setOut(legalOut);
+        System.setErr(legalErr);
+
+        // our setter lifecycle
+        StandardOutputSetter.set();
+        StandardOutputSetter.reset();
+
+        // checking that we set back legal streams
+        assertSame(legalOut, System.out);
+        assertSame(legalErr, System.err);
+    }
+
+}

--- a/allure-java-aspects/src/test/java/ru/yandex/qatools/allure/logging/TestStepLogsTest.java
+++ b/allure-java-aspects/src/test/java/ru/yandex/qatools/allure/logging/TestStepLogsTest.java
@@ -1,0 +1,87 @@
+package ru.yandex.qatools.allure.logging;
+
+import org.junit.Test;
+
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Queue;
+import java.util.Random;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Created by Mihails Volkovs on 2015.03.06.
+ */
+public class TestStepLogsTest {
+
+    @Test
+    public void singleThread() {
+        PrintStream out = new PrintStream(TestStepLogs.INSTANCE);
+        out.print("Before...");
+        TestStepLogs.addLog();
+        out.print("TestStep|");
+        TestStepLogs.addLog();
+        out.print("NestedTestStep|");
+        assertThat(TestStepLogs.removeLog(), is("NestedTestStep|"));
+        assertThat(TestStepLogs.removeLog(), is("TestStep|NestedTestStep|"));
+        assertThat(TestStepLogs.removeLog(), is(""));
+    }
+
+    @Test
+    public void parallelExecution() throws InterruptedException {
+        final PrintStream out = new PrintStream(TestStepLogs.INSTANCE);
+        out.print("Before...");
+        TestStepLogs.addLog();
+        out.print("Test|");
+
+        Queue<String> logs = new ConcurrentLinkedQueue<String>();
+        List<LoggingThread> childThreads = new ArrayList<LoggingThread>();
+        final int THREADS_COUNT = 50;
+        for (int i = 0; i < THREADS_COUNT; i++) {
+            LoggingThread loggingThread = new LoggingThread(out, "" + i, logs);
+            childThreads.add(loggingThread);
+            loggingThread.start();
+        }
+        for (Thread thread : childThreads) {
+            thread.join();
+        }
+
+        // log messages by different threads are not mixed up
+        assertThat(TestStepLogs.removeLog(), is("Test|"));
+        assertThat(TestStepLogs.removeLog(), is(""));
+        assertThat(logs.size(), is(THREADS_COUNT));
+        for (int i = 0; i < THREADS_COUNT; i++) {
+            assertThat(logs, hasItem("child thread: " + i));
+        }
+    }
+
+    private static class LoggingThread extends Thread {
+
+        private PrintStream out;
+
+        private Queue<String> logs;
+
+        private LoggingThread(PrintStream out, String name, Queue<String> logs) {
+            super(name);
+            this.out = out;
+            this.logs = logs;
+        }
+
+        @Override
+        public void run() {
+            TestStepLogs.addLog();
+            try {
+                Thread.sleep(new Random().nextInt(100));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            out.print("child thread: " + getName());
+            logs.add(TestStepLogs.removeLog());
+        }
+
+    }
+}

--- a/allure-model/src/main/java/ru/yandex/qatools/allure/config/AllureConfig.java
+++ b/allure-model/src/main/java/ru/yandex/qatools/allure/config/AllureConfig.java
@@ -54,6 +54,9 @@ public class AllureConfig {
     @Property("allure.attachments.encoding")
     private String attachmentsEncoding = "UTF-8";
 
+    @Property("allure.attachments.log")
+    private boolean attachLogs = false;
+
     @Property("allure.max.title.length")
     private int maxTitleLength = 120;
 
@@ -129,6 +132,10 @@ public class AllureConfig {
             LOGGER.trace("Can't find attachments encoding \"" + attachmentsEncoding, "\" use default", e);
             return Charset.defaultCharset();
         }
+    }
+
+    public boolean attachLogs() {
+        return attachLogs;
     }
 
     public static File getDefaultResultsDirectory() { // NOSONAR


### PR DESCRIPTION
Attempt to automatically attach logs to test steps. 

Since logs could take too many disk space this feature is optional turned off by default. To enable it update AllureConfig e.g. by -Dallure.attachments.log=true.

To eliminate coupling with test frameworks we replace standard output, so any console based logging will be visible also in report.

Implementation contains 3 classes by Apache commons IO - I was afraid to add extra dependency.

Concurrently running test logs are not mixed up. Logs are hierarchical. Please note that outer test step / test logs contain all the logs of inner test steps:
![image](https://cloud.githubusercontent.com/assets/743546/6528090/60d333ac-c428-11e4-864b-2db7686652bd.png)
![image](https://cloud.githubusercontent.com/assets/743546/6528101/79ab70ba-c428-11e4-8453-3c5d97f8106f.png)
![image](https://cloud.githubusercontent.com/assets/743546/6528112/8dc91066-c428-11e4-9361-7bb4eec7ba51.png)

I have tested it in both JUnit and TestNG. Some integration test might be added in future.

If idea in general is accepted, UI could be updated in following way. Do not show log attachments. Show log on according test step selection.