### PR TITLE
Adding parametrized (TestNG) test support (back-end)

### DIFF
--- a/allure-java-adaptor-api/src/main/java/ru/yandex/qatools/allure/events/AddParameterEvent.java
+++ b/allure-java-adaptor-api/src/main/java/ru/yandex/qatools/allure/events/AddParameterEvent.java
@@ -22,8 +22,20 @@ public class AddParameterEvent extends AbstractTestCaseAddParameterEvent {
      * @param value of parameter to add
      */
     public AddParameterEvent(String name, String value) {
+        this(name, value, ParameterKind.ENVIRONMENT_VARIABLE);
+    }
+
+    /**
+     * Constructs an new event with specified name and value
+     *
+     * @param name  of parameter to add
+     * @param value of parameter to add
+     * @param kind of parameter to add
+     */
+    public AddParameterEvent(String name, String value, ParameterKind kind) {
         setName(name);
         setValue(value);
+        setKind(kind.name());
     }
 
     /**
@@ -36,7 +48,7 @@ public class AddParameterEvent extends AbstractTestCaseAddParameterEvent {
         context.getParameters().add(new Parameter()
                         .withName(getName())
                         .withValue(getValue())
-                        .withKind(ParameterKind.ENVIRONMENT_VARIABLE)
+                        .withKind(ParameterKind.valueOf(getKind()))
         );
     }
 }

--- a/allure-java-adaptor-api/src/main/resources/allure.events.xsd
+++ b/allure-java-adaptor-api/src/main/resources/allure.events.xsd
@@ -88,6 +88,7 @@
         <xsd:all>
             <xsd:element name="name" type="xsd:string" nillable="false"/>
             <xsd:element name="value" type="xsd:string" nillable="false"/>
+            <xsd:element name="kind" type="xsd:string" default="environment-variable"/>
         </xsd:all>
     </xsd:complexType>
 

--- a/allure-java-annotations/src/main/java/ru/yandex/qatools/allure/annotations/Parameter.java
+++ b/allure-java-annotations/src/main/java/ru/yandex/qatools/allure/annotations/Parameter.java
@@ -34,7 +34,7 @@ import java.lang.annotation.Target;
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.FIELD)
+@Target({ElementType.FIELD, ElementType.PARAMETER})
 public @interface Parameter {
 
     String value() default "";

--- a/allure-testng-adaptor/src/main/java/ru/yandex/qatools/allure/testng/AllureTestListener.java
+++ b/allure-testng-adaptor/src/main/java/ru/yandex/qatools/allure/testng/AllureTestListener.java
@@ -1,5 +1,7 @@
 package ru.yandex.qatools.allure.testng;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testng.IConfigurationListener;
 import org.testng.ITestContext;
 import org.testng.ITestListener;
@@ -8,7 +10,9 @@ import org.testng.ITestResult;
 import org.testng.SkipException;
 import org.testng.TestException;
 import ru.yandex.qatools.allure.Allure;
+import ru.yandex.qatools.allure.annotations.Parameter;
 import ru.yandex.qatools.allure.config.AllureModelUtils;
+import ru.yandex.qatools.allure.events.AddParameterEvent;
 import ru.yandex.qatools.allure.events.TestCaseCanceledEvent;
 import ru.yandex.qatools.allure.events.TestCaseFailureEvent;
 import ru.yandex.qatools.allure.events.TestCaseFinishedEvent;
@@ -17,11 +21,15 @@ import ru.yandex.qatools.allure.events.TestCaseStartedEvent;
 import ru.yandex.qatools.allure.events.TestSuiteFinishedEvent;
 import ru.yandex.qatools.allure.events.TestSuiteStartedEvent;
 import ru.yandex.qatools.allure.model.Description;
+import ru.yandex.qatools.allure.model.ParameterKind;
 import ru.yandex.qatools.allure.utils.AnnotationManager;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -35,13 +43,14 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class AllureTestListener implements ITestListener, IConfigurationListener {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(AllureTestListener.class);
+
     private Allure lifecycle = Allure.LIFECYCLE;
 
-    private Map<String, String> suiteUid = new HashMap<String, String>();
+    private Map<String, String> suiteUid = new HashMap<>();
 
     private Set<String> startedTestNames = Collections.newSetFromMap(
             new ConcurrentHashMap<String, Boolean>());
-
 
     @Override
     public void onConfigurationSuccess(ITestResult iTestResult) {
@@ -108,11 +117,12 @@ public class AllureTestListener implements ITestListener, IConfigurationListener
 
     @Override
     public void onTestStart(ITestResult iTestResult) {
+        ITestNGMethod method = iTestResult.getMethod();
         String suitePrefix = getCurrentSuitePrefix(iTestResult);
         String testName = getName(iTestResult);
         startedTestNames.add(testName);
         testName = testName.replace(suitePrefix, "");
-        Description description = new Description().withValue(iTestResult.getMethod().getDescription());
+        Description description = new Description().withValue(method.getDescription());
         TestCaseStartedEvent event = new TestCaseStartedEvent(getSuiteUid(iTestResult.getTestContext()), testName);
         if (description.getValue() != null) {
             event.setDescription(description);
@@ -122,6 +132,7 @@ public class AllureTestListener implements ITestListener, IConfigurationListener
         am.update(event);
 
         getLifecycle().fire(event);
+        fireAddParameterEvents(iTestResult);
     }
 
     @Override
@@ -233,4 +244,103 @@ public class AllureTestListener implements ITestListener, IConfigurationListener
         }
         return uid;
     }
+
+    /**
+     * Creates test case parameters in XML in case of parametrized test (see TestNG @DataProvider).
+     * Java 8 allows to keep test method parameter names in class files (needs javac -parameters compilation).
+     * In Java 7 default parameter naming is used (arg0, arg1, ... ).
+     *
+     * @param iTestResult parameter passed to onTestStart() callback by TestNG
+     * @see #getNameForParameter(String, List, int)
+     * @see #getMethodParameterNamesIfAvailable(Method)
+     */
+    private void fireAddParameterEvents(ITestResult iTestResult) {
+        Object[] parameters = iTestResult.getParameters();
+
+        Method nativeMethod = iTestResult.getMethod().getConstructorOrMethod().getMethod();
+        Annotation[][] parametersAnnotations = nativeMethod.getParameterAnnotations();
+
+        List<String> methodParameterNames = getMethodParameterNamesIfAvailable(nativeMethod);
+
+        for (int i = 0; i < parameters.length; i++) {
+            Parameter parameter = getParameterAnnotation(parametersAnnotations[i]);
+            if (parameter == null) {
+                return;
+            }
+
+            String name = getNameForParameter(parameter.value(), methodParameterNames, i);
+            String value = parameters[i].toString();
+
+            getLifecycle().fire(new AddParameterEvent(name, value, ParameterKind.ARGUMENT));
+        }
+    }
+
+    /**
+     * Generate name for parameter.
+     */
+    private String getNameForParameter(String valueInAnnotation, List<String> methodParameterNames, int index) {
+        if (!"".equals(valueInAnnotation)) {
+            return valueInAnnotation;
+        }
+
+        if (index < methodParameterNames.size()) {
+            return methodParameterNames.get(index);
+        }
+
+        return "arg" + index;
+    }
+
+    /**
+     * Find {@link Parameter} annotation in given array of annotations.
+     */
+    private Parameter getParameterAnnotation(Annotation[] annotations) {
+        for (Annotation annotation : annotations) {
+            if (annotation instanceof Parameter) {
+                return (Parameter) annotation;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Returns true if can get method parameter names. Since java 8 you can get parameter names via
+     * reflection if <code>-parameters</code> compiler argument specified. For more information
+     * you can see documentation at
+     * https://docs.oracle.com/javase/tutorial/reflect/member/methodparameterreflection.html .
+     */
+    private boolean canGetMethodParameterNames() { //NOSONAR
+        try {
+            Class.forName("java.lang.reflect.Parameter", false, getClass().getClassLoader());
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Returns method parameter names if can.
+     *
+     * @see #canGetMethodParameterNames()
+     */
+    private List<String> getMethodParameterNamesIfAvailable(Method testMethod) {
+        List<String> result = new ArrayList<>();
+
+        if (!canGetMethodParameterNames()) {
+            return result;
+        }
+
+        try {
+            Object[] parameters = (Object[]) testMethod.getClass().getMethod("getParameters").invoke(testMethod);
+            for (Object parameter : parameters) {
+                result.add((String) parameter.getClass().getMethod("getName").invoke(parameter));
+            }
+            return result;
+        } catch (Exception e) {
+            String errorMessage = "Could not access parameter names via reflection. " +
+                    "Falling back to default test method parameter names.";
+            LOGGER.warn(errorMessage, e);
+        }
+        return result;
+    }
+
 }

--- a/allure-testng-adaptor/src/test/java/ru/yandex/qatools/allure/testng/AllureTestListenerTest.java
+++ b/allure-testng-adaptor/src/test/java/ru/yandex/qatools/allure/testng/AllureTestListenerTest.java
@@ -1,21 +1,32 @@
 package ru.yandex.qatools.allure.testng;
 
-import org.junit.*;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 import org.testng.ISuite;
 import org.testng.ITestContext;
 import org.testng.ITestNGMethod;
 import org.testng.ITestResult;
+import org.testng.internal.ConstructorOrMethod;
 import org.testng.xml.XmlTest;
-
 import ru.yandex.qatools.allure.Allure;
-import ru.yandex.qatools.allure.events.*;
+import ru.yandex.qatools.allure.annotations.Parameter;
+import ru.yandex.qatools.allure.events.AddParameterEvent;
+import ru.yandex.qatools.allure.events.TestCaseCanceledEvent;
+import ru.yandex.qatools.allure.events.TestCaseFinishedEvent;
+import ru.yandex.qatools.allure.events.TestCaseStartedEvent;
+import ru.yandex.qatools.allure.model.ParameterKind;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.*;
 import static ru.yandex.qatools.allure.utils.AnnotationManager.withExecutorInfo;
@@ -33,7 +44,9 @@ public class AllureTestListenerTest {
     private AllureTestListener testngListener;
     private Allure allure;
     private ITestContext testContext;
-    
+    private ITestResult testResult;
+    private ITestNGMethod method;
+
     @Before
     public void setUp() {
         testngListener = spy(new AllureTestListener());
@@ -48,17 +61,22 @@ public class AllureTestListenerTest {
     	testContext = mock(ITestContext.class);
     	when(testContext.getSuite()).thenReturn(suite);
     	when(testContext.getCurrentXmlTest()).thenReturn(xmlTest);
+
+        // mocking test method parameters
+        ConstructorOrMethod constructorOrMethod = mock(ConstructorOrMethod.class);
+        when(constructorOrMethod.getMethod()).thenReturn(parametrizedTestMethod(0, null, null));
+        method = mock(ITestNGMethod.class);
+        when(method.getConstructorOrMethod()).thenReturn(constructorOrMethod);
+        testResult = mock(ITestResult.class);
+        when(testResult.getMethod()).thenReturn(method);
+        when(testResult.getParameters()).thenReturn(new Object[]{});
     }
 
     @Test
     public void skipTestFireTestCaseStartedEvent() {
-        ITestResult testResult = mock(ITestResult.class);
         when(testResult.getName()).thenReturn(DEFAULT_TEST_NAME);
         when(testResult.getTestContext()).thenReturn(testContext);
         doReturn(new Annotation[0]).when(testngListener).getMethodAnnotations(testResult);
-        ITestNGMethod method = mock(ITestNGMethod.class);
-        when(method.getDescription()).thenReturn(null);
-        when(testResult.getMethod()).thenReturn(method);
 
         testngListener.onTestSkipped(testResult);
 
@@ -68,15 +86,11 @@ public class AllureTestListenerTest {
 
     @Test
     public void skipTestWithThrowable() {
-        ITestResult testResult = mock(ITestResult.class);
         Throwable throwable = new NullPointerException();
         when(testResult.getTestContext()).thenReturn(testContext);
         when(testResult.getThrowable()).thenReturn(throwable);
         when(testResult.getName()).thenReturn(DEFAULT_TEST_NAME);
-        ITestNGMethod method = mock(ITestNGMethod.class);
-        when(method.getDescription()).thenReturn(null);
-        when(testResult.getMethod()).thenReturn(method);
-        
+
         doReturn(new Annotation[0]).when(testngListener).getMethodAnnotations(testResult);
 
         testngListener.onTestSkipped(testResult);
@@ -86,13 +100,9 @@ public class AllureTestListenerTest {
 
     @Test
     public void skipTestWithoutThrowable() {
-        ITestResult testResult = mock(ITestResult.class);
         when(testResult.getTestContext()).thenReturn(testContext);
         when(testResult.getName()).thenReturn(DEFAULT_TEST_NAME);
-        ITestNGMethod method = mock(ITestNGMethod.class);
-        when(method.getDescription()).thenReturn(null);
-        when(testResult.getMethod()).thenReturn(method);
-        
+
         doReturn(new Annotation[0]).when(testngListener).getMethodAnnotations(testResult);
 
         testngListener.onTestSkipped(testResult);
@@ -102,14 +112,10 @@ public class AllureTestListenerTest {
 
     @Test
     public void skipTestFiredEventsOrder() {
-        ITestResult testResult = mock(ITestResult.class);
         when(testResult.getTestContext()).thenReturn(testContext);
         when(testResult.getThrowable()).thenReturn(new NullPointerException());
         when(testResult.getName()).thenReturn(DEFAULT_TEST_NAME);
-        ITestNGMethod method = mock(ITestNGMethod.class);
-        when(method.getDescription()).thenReturn(null);
-        when(testResult.getMethod()).thenReturn(method);
-        
+
         doReturn(new Annotation[0]).when(testngListener).getMethodAnnotations(testResult);
 
         testngListener.onTestSkipped(testResult);
@@ -124,22 +130,48 @@ public class AllureTestListenerTest {
     public void parametrizedTest() {
         double doubleParameter = 10.0;
         String stringParameter = "string";
-        ITestResult testResult = mock(ITestResult.class);
+        String anotherStringParameter = "anotherString";
         when(testResult.getTestContext()).thenReturn(testContext);
         when(testResult.getName()).thenReturn(DEFAULT_TEST_NAME);
-        when(testResult.getParameters()).thenReturn(new Object[] { doubleParameter, stringParameter});
-        ITestNGMethod method = mock(ITestNGMethod.class);
-        when(method.getDescription()).thenReturn(null);
-        when(testResult.getMethod()).thenReturn(method);
-        
+        when(testResult.getParameters()).thenReturn(new Object[] { doubleParameter, stringParameter, anotherStringParameter});
+
         doReturn(new Annotation[0]).when(testngListener).getMethodAnnotations(testResult);
 
         testngListener.onTestStart(testResult);
 
         String suiteUid = testngListener.getSuiteUid(testContext);
-        String testName = String.format("%s[%s,%s]",
-                DEFAULT_TEST_NAME, Double.toString(doubleParameter), stringParameter);
+        String testName = String.format("%s[%s,%s,%s]",
+                DEFAULT_TEST_NAME, Double.toString(doubleParameter), stringParameter, anotherStringParameter);
         verify(allure).fire(eq(withExecutorInfo(new TestCaseStartedEvent(suiteUid, testName))));
+
+        ArgumentCaptor<AddParameterEvent> captor = ArgumentCaptor.forClass(AddParameterEvent.class);
+        verify(allure, times(2)).fire(captor.capture());
+
+        Iterator<AddParameterEvent> addParameterEvents = captor.getAllValues().iterator();
+        assertParameterEvent("doubleParameter", doubleParameter + "", addParameterEvents.next(), false);
+        assertParameterEvent("valueFromAnnotation", stringParameter, addParameterEvents.next(), true);
+        assertFalse(addParameterEvents.hasNext());
+    }
+
+    private void assertParameterEvent(@SuppressWarnings("UnusedParameters") String expectedName, String expectedValue, AddParameterEvent event, boolean annotatedParameter) {
+
+        // argument name is available only since Java 8 if compiled javac with -parameters key
+        // or if explicitly marked with @ru.yandex.qatools.allure.annotations.Parameter annotation
+        if (annotatedParameter) {
+            assertEquals(expectedName, event.getName());
+        }
+
+        assertEquals(expectedValue, event.getValue());
+        assertEquals(ParameterKind.ARGUMENT.name(), event.getKind());
+    }
+
+    @SuppressWarnings("UnusedParameters")
+    public Method parametrizedTestMethod(@Parameter double doubleParameter, @Parameter("valueFromAnnotation") String stringParameter, String notParameter) {
+        try {
+            return getClass().getDeclaredMethod("parametrizedTestMethod", double.class, String.class, String.class);
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Test


### PR DESCRIPTION
This is first step to support parametrized tests (@ DataProvider in TestNG, @ Parameters in JUnit). TestNG adapter only. 
 - In XML parameter kind 'ARGUMENT' is used. 
 - Later support on UI will be added.
 - If compiled by Java 8 with javac -parameters, real test method argument names will be taken. 
 - Java 7 compatible.