### PR TITLE
Adding parametrized (TestNG) test support (front-end)

### DIFF
--- a/allure-model/src/test/resources/allure-results/a179d781-ed1f-4d54-b146-59984be84462-testsuite.xml
+++ b/allure-model/src/test/resources/allure-results/a179d781-ed1f-4d54-b146-59984be84462-testsuite.xml
@@ -47,6 +47,8 @@
             </labels>
             <parameters>
                 <parameter name="Argument" value="0" kind="environment-variable"/>
+                <parameter name="param1" value="value1" kind="argument"/>
+                <parameter name="param2" value="value2" kind="argument"/>
             </parameters>
         </test-case>
         <test-case start="1412949540692" stop="1412949542295" status="passed">
@@ -88,7 +90,7 @@
                 <label name="thread" value="pool-1-thread-23"/>
             </labels>
             <parameters>
-                <parameter name="Argument" value="13" kind="environment-variable"/>
+                <parameter name="param" value="value" kind="argument"/>
             </parameters>
         </test-case>
         <test-case start="1412949540693" stop="1412949541752" status="canceled">

--- a/allure-report-face/src/main/less/blocks/testcase.less
+++ b/allure-report-face/src/main/less/blocks/testcase.less
@@ -72,3 +72,9 @@
 .fa-database {
   font-size: 14px;
 }
+
+.parameter-value {
+  max-width: 300px;
+  display: inline-block;
+  vertical-align: top;
+}

--- a/allure-report-face/src/main/webapp/js/testcase/testcase.js
+++ b/allure-report-face/src/main/webapp/js/testcase/testcase.js
@@ -70,6 +70,10 @@ angular.module('allure.core.testcase.controllers', ['d3'])
 
         findFailedStep($scope.testcase);
 
+        $scope.testcaseArguments = testcase.parameters ? testcase.parameters.filter(function (el) {
+            return el.kind === "ARGUMENT";
+        }) : [];
+
         $scope.isState = function(state) {
             return $state.is(baseState + '.' + state);
         };

--- a/allure-report-face/src/main/webapp/templates/testcase/testcase.html
+++ b/allure-report-face/src/main/webapp/templates/testcase/testcase.html
@@ -13,6 +13,20 @@
         <small translate="testcase.SEVERITY" translate-value-severity="{{testcase.severity | translate}}"></small>
     </h3>
     <div class="external-system-references">
+        <span ng-show="testcaseArguments.length > 0">
+            <span class="fa fa-sliders"/>
+            <span>{{'testcase.PARAMETERS' | translate}}: [</span>
+            <span ng-repeat="argument in testcaseArguments">
+                <span class="line-nobreak">
+                    <span>{{argument.name}} = "
+                        <span title = {{argument.value}} class="line-ellipsis parameter-value">{{argument.value}} </span>
+                        "
+                    </span>
+                    <span ng-show="!$last">;</span>
+                </span>
+            </span>
+            <span>]</span>
+        </span>
         <span class="issues" ng-show="testcase.issues">
             <span class="fa fa-bug"/>
             {{'testcase.ISSUES' | translate}}

--- a/allure-report-face/src/main/webapp/translations/en.json
+++ b/allure-report-face/src/main/webapp/translations/en.json
@@ -88,6 +88,7 @@
               "RAW": "Raw",
               "STACKTRACE": "Stacktrace",
               "SUBSTEPS": "{substeps, plural, one{# sub-step} other{# sub-steps}}",
-              "ATTACHMENTS": "{attachments, plural, one{# attachment} other{# attachments}}"
+              "ATTACHMENTS": "{attachments, plural, one{# attachment} other{# attachments}}",
+              "PARAMETERS" : "Parameters"
           }  
 }

--- a/allure-report-face/src/main/webapp/translations/ru.json
+++ b/allure-report-face/src/main/webapp/translations/ru.json
@@ -87,6 +87,7 @@
             "RAW": "Исходник",
             "STACKTRACE": "Трассировка",
             "SUBSTEPS": "{substeps, plural, one{# подшаг} few{# подшага} other{# подшагов}}",
-            "ATTACHMENTS": "{attachments, plural, one{# приложение} few{# приложения} other{# приложений}}"
+            "ATTACHMENTS": "{attachments, plural, one{# приложение} few{# приложения} other{# приложений}}",
+            "PARAMETERS" : "Параметры"
         }
 }

--- a/allure-report-face/src/test/webapp/core/testcase/testcaseSpec.js
+++ b/allure-report-face/src/test/webapp/core/testcase/testcaseSpec.js
@@ -213,6 +213,32 @@ describe('Testcase controllers', function() {
             expect(scope.testcase.steps[1].steps[1].failure.error).toBe(scope.failure.error);
         });
 
+        describe('testcaseArguments checks', function () {
+            var testcase = {
+                parameters: [
+                    {kind: 'ARGUMENT'},
+                    {kind: 'SYSTEM_PROPERTY'}
+                ],
+                steps: []
+            };
+
+            it('should contain single argument of type "ARGUMENT"', function () {
+                scope = createController(testcase);
+                expect(scope.testcaseArguments.length).toBe(1);
+                expect(scope.testcaseArguments[0].kind).toBe(testcase.parameters[0].kind);
+            });
+            it('should contain empty array', function () {
+                testcase.parameters = [];
+                scope = createController(testcase);
+                expect(scope.testcaseArguments.length).toBe(0);
+            });
+            it('should contain empty array', function () {
+                testcase = {steps: []};
+                scope = createController(testcase);
+                expect(scope.testcaseArguments.length).toBe(0);
+            });
+        });
+
         describe('state checks', function() {
             beforeEach(function() {
                 scope = createController({steps: []});


### PR DESCRIPTION
@just-boris UI part of https://github.com/allure-framework/allure-core/pull/534

Views can be still played around with. Providing several variants:

1. Huge text, JSON style parameters, sliders icon:
![image](https://cloud.githubusercontent.com/assets/743546/6713074/cb4d5a54-cd98-11e4-9d43-1df72c7a088a.png)

2. Current pull request:
![image](https://cloud.githubusercontent.com/assets/743546/6713145/344a66e6-cd99-11e4-9fc5-efab94f0f728.png)

Sample test suite my.company.ParametrizedTest XML has been updated (allure-model module).

P.S. If allure-test-case-info in testcase.xsd is extended with parameters it will be possible to see them in test case list as well:
![image](https://cloud.githubusercontent.com/assets/743546/6713215/9d6d005c-cd99-11e4-858f-308a6ffe72df.png)
But may be that will break Allure table simplicity.