### PR TITLE
Add packaging without services for adapters

### DIFF
--- a/allure-junit-adaptor/pom.xml
+++ b/allure-junit-adaptor/pom.xml
@@ -53,6 +53,25 @@
                    </excludes>
                </configuration>
            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.6</version>
+                <executions>
+                    <execution>
+                        <id>spi-off</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <classifier>spi-off</classifier>
+                            <excludes>
+                                <exclude>**/META-INF/services/**</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/allure-testng-adaptor/pom.xml
+++ b/allure-testng-adaptor/pom.xml
@@ -63,6 +63,25 @@
                     </dependency>
                 </dependencies>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.6</version>
+                <executions>
+                    <execution>
+                        <id>spi-off</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <classifier>spi-off</classifier>
+                            <excludes>
+                                <exclude>**/META-INF/services/**</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
Now you can use `spi-off` classifier do disable adaptors loading via SPI