### PR TITLE
Fixing bug with method parameters

### DIFF
--- a/allure-testng-adaptor/src/main/java/ru/yandex/qatools/allure/testng/AllureTestListener.java
+++ b/allure-testng-adaptor/src/main/java/ru/yandex/qatools/allure/testng/AllureTestListener.java
@@ -318,10 +318,7 @@ public class AllureTestListener implements IResultListener, ISuiteListener {
     }
 
     private boolean isAfterSuiteConfigMethod(ITestResult iTestResult) {
-        if (getConfigMethodType(iTestResult).equals(ConfigMethodType.AfterSuite)) {
-            return true;
-        }
-        return false;
+        return ConfigMethodType.AfterSuite.equals(getConfigMethodType(iTestResult));
     }
         
     /**
@@ -398,7 +395,7 @@ public class AllureTestListener implements IResultListener, ISuiteListener {
         for (int i = 0; i < parameters.length; i++) {
             Parameter parameter = getParameterAnnotation(parametersAnnotations[i]);
             if (parameter == null) {
-                return;
+                continue;
             }
 
             String name = getNameForParameter(parameter.value(), methodParameterNames, i);

--- a/allure-testng-adaptor/src/test/java/ru/yandex/qatools/allure/testng/AllureTestListenerTest.java
+++ b/allure-testng-adaptor/src/test/java/ru/yandex/qatools/allure/testng/AllureTestListenerTest.java
@@ -141,7 +141,7 @@ public class AllureTestListenerTest {
 
         Iterator<AddParameterEvent> addParameterEvents = captor.getAllValues().iterator();
         assertParameterEvent("doubleParameter", doubleParameter + "", addParameterEvents.next(), false);
-        assertParameterEvent("valueFromAnnotation", stringParameter, addParameterEvents.next(), true);
+        assertParameterEvent("valueFromAnnotation", anotherStringParameter, addParameterEvents.next(), true);
         assertFalse(addParameterEvents.hasNext());
     }
 
@@ -158,7 +158,7 @@ public class AllureTestListenerTest {
     }
 
     @SuppressWarnings("UnusedParameters")
-    public Method parametrizedTestMethod(@Parameter double doubleParameter, @Parameter("valueFromAnnotation") String stringParameter, String notParameter) {
+    public Method parametrizedTestMethod(@Parameter double doubleParameter, String notParameter, @Parameter("valueFromAnnotation") String stringParameter) {
         try {
             return getClass().getDeclaredMethod("parametrizedTestMethod", double.class, String.class, String.class);
         } catch (NoSuchMethodException e) {


### PR DESCRIPTION
- Processing all the annotated parameters instead of returning on first non-annotated parameter
- Fixing warnings in `isAfterSuiteConfigMethod()`