### PR TITLE
xUnit: consistent order of test run statuses

### DIFF
--- a/allure-report-face/src/main/webapp/plugins/xunit/testrun.html
+++ b/allure-report-face/src/main/webapp/plugins/xunit/testrun.html
@@ -19,16 +19,16 @@
             </td>
             <td class="line-nobreak">{{time.duration | time}}</td>
             <td class="text-center">
-                <span class="label label-default" ng-show="statistic.canceled > 0">{{statistic.canceled}}</span>
-            </td>
-            <td class="text-center">
-                <span class="label label-status-pending" ng-show="statistic.pending > 0">{{statistic.pending}}</span>
+                <span class="label label-danger" ng-show="statistic.failed > 0">{{statistic.failed}}</span>
             </td>
             <td class="text-center">
                 <span class="label label-warning" ng-show="statistic.broken > 0">{{statistic.broken}}</span>
             </td>
             <td class="text-center">
-                <span class="label label-danger" ng-show="statistic.failed > 0">{{statistic.failed}}</span>
+                <span class="label label-default" ng-show="statistic.canceled > 0">{{statistic.canceled}}</span>
+            </td>
+            <td class="text-center">
+                <span class="label label-status-pending" ng-show="statistic.pending > 0">{{statistic.pending}}</span>
             </td>
             <td class="text-center">
                 {{statistic.total}}
@@ -41,17 +41,17 @@
             <td allure-table-col="{heading: 'Duration', predicate: 'time.duration', flex: 2, reverse: true}" class="line-ellipsis" title="{{testsuite.time.duration | time}}">
                 {{testsuite.time.duration | time}}
             </td>
+            <td allure-table-col="{heading: 'Failed', predicate: 'statistic.failed', class:'text-center', reverse: true}" class="text-center">
+                <span class="label label-danger" ng-show="testsuite.statistic.failed > 0">{{testsuite.statistic.failed}}</span>
+            </td>
+            <td allure-table-col="{heading: 'Broken', predicate: 'statistic.broken', class:'text-center', reverse: true}" class="text-center">
+                <span class="label label-warning" ng-show="testsuite.statistic.broken > 0">{{testsuite.statistic.broken}}</span>
+            </td>
             <td allure-table-col="{heading: 'Canceled', predicate: 'statistic.canceled', class:'text-center', reverse: true}" class="text-center">
                 <span class="label label-default" ng-show="testsuite.statistic.canceled > 0">{{testsuite.statistic.canceled}}</span>
             </td>
             <td allure-table-col="{heading: 'Pending', predicate: 'statistic.pending', class:'text-center', reverse: true}" class="text-center">
                 <span class="label label-status-pending" ng-show="testsuite.statistic.pending > 0">{{testsuite.statistic.pending}}</span>
-            </td>
-            <td allure-table-col="{heading: 'Broken', predicate: 'statistic.broken', class:'text-center', reverse: true}" class="text-center">
-                <span class="label label-warning" ng-show="testsuite.statistic.broken > 0">{{testsuite.statistic.broken}}</span>
-            </td>
-            <td allure-table-col="{heading: 'Failed', predicate: 'statistic.failed', class:'text-center', reverse: true}" class="text-center">
-                <span class="label label-danger" ng-show="testsuite.statistic.failed > 0">{{testsuite.statistic.failed}}</span>
             </td>
             <td allure-table-col="{heading: 'Total', predicate: 'statistic.total', class:'text-center', reverse: true}" class="text-center">
                 {{testsuite.statistic.total}}


### PR DESCRIPTION
xUnit plugin: test run status order is not consistent with both filter buttons and Behaviours plugin.

Before:
![before](https://cloud.githubusercontent.com/assets/743546/9065341/9be6780a-3ad9-11e5-98bc-8ec5722f9267.png)

After:
![after](https://cloud.githubusercontent.com/assets/743546/9065350/a042c728-3ad9-11e5-82b4-5ca8359b7b9f.png)

