### PR TITLE
SVG attachment viewer

### DIFF
--- a/allure-report-face/src/main/webapp/js/testcase/testcase.js
+++ b/allure-report-face/src/main/webapp/js/testcase/testcase.js
@@ -28,6 +28,8 @@ angular.module('allure.core.testcase.controllers', ['d3'])
                     return "html";
                 case 'text/csv':
                     return "csv";
+                case 'image/svg+xml':
+                    return "svg";
                 default:
             }
         };
@@ -91,11 +93,12 @@ angular.module('allure.core.testcase.controllers', ['d3'])
             $scope.setAttachment((direction < 0 ? allAttachments.getPrevious(index) : allAttachments.getNext(index)).uid);
         };
 
-        $scope.getIconClass = function(type) {
+        $scope.getIconClass = function(type) { //NOSONAR
             switch (attachmentType(type)) {
                 case 'text':
                     return 'fa fa-file-text-o';
                 case 'image':
+                case 'svg':
                     return 'fa fa-file-image-o';
                 case 'code':
                     return 'fa fa-file-code-o';

--- a/allure-report-face/src/main/webapp/templates/testcase/attachment.html
+++ b/allure-report-face/src/main/webapp/templates/testcase/attachment.html
@@ -30,6 +30,9 @@
         <div ng-switch-when="code">
             <pre><code data-language="{{language}}" highlight="attachText"></code></pre>
         </div>
+        <div ng-switch-when="svg" class="text-center">
+            <object type="image/svg+xml" data="{{getSourceUrl(attachment)}}">Your browser does not support SVG</object>
+        </div>
         <div ng-switch-default>
             <iframe style="width: 100%; min-height: 600px;" frameborder="0" ng-src="{{getSourceUrl(attachment)}}" on-error="onError()"></iframe>
         </div>


### PR DESCRIPTION
- image/svg+xml mime type
- Interactive (javascript) svg supported
- `<object/>` was used as recommended at http://www.sitepoint.com/add-svg-to-web-page/ - interactive images are supported.
- HTML contains fallback: "Your browser does not support SVG". All modern browsers do support SVG. Regular user will never see it. So, the message is not translated to minimize localization (maintenance) cost.

![image](https://cloud.githubusercontent.com/assets/743546/9282965/f2314ad2-42c7-11e5-9689-c8ab103feb26.png)

![image](https://cloud.githubusercontent.com/assets/743546/9282988/12cc77d0-42c8-11e5-9303-c3d23e8edcc2.png)


