### PR TITLE
bug fix: close result file writer

### DIFF
--- a/allure-java-adaptor-api/src/main/java/ru/yandex/qatools/allure/utils/AllureResultsUtils.java
+++ b/allure-java-adaptor-api/src/main/java/ru/yandex/qatools/allure/utils/AllureResultsUtils.java
@@ -142,10 +142,10 @@ public final class AllureResultsUtils {
      * @param testSuite to marshal
      */
     public static void writeTestSuiteResult(TestSuiteResult testSuite, File testSuiteResultFile) {
-        try {
+        try (BadXmlCharacterFilterWriter writer = new BadXmlCharacterFilterWriter(testSuiteResultFile)) {
             marshaller(TestSuiteResult.class).marshal(
                     new ObjectFactory().createTestSuite(testSuite),
-                    new BadXmlCharacterFilterWriter(testSuiteResultFile)
+                    writer
             );
         } catch (Exception e) {
             LOGGER.error("Error while marshaling testSuite", e);

--- a/allure-java-adaptor-api/src/test/java/ru/yandex/qatools/allure/utils/WriteTestSuiteResultTest.java
+++ b/allure-java-adaptor-api/src/test/java/ru/yandex/qatools/allure/utils/WriteTestSuiteResultTest.java
@@ -11,7 +11,10 @@ import ru.yandex.qatools.allure.model.TestSuiteResult;
 import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Validator;
 import java.io.File;
+import java.nio.file.Files;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static ru.yandex.qatools.allure.commons.AllureFileUtils.listTestSuiteFiles;
 
 /**
@@ -46,6 +49,18 @@ public class WriteTestSuiteResultTest {
         for (File each : listTestSuiteFiles(resultsDirectory)) {
             validator.validate(new StreamSource(each));
         }
+    }
+
+    @Test
+    public void shouldCloseResultFileTest() throws Exception {
+        File resultFile = new File(folder.getRoot(), "suite.xml");
+
+        AllureResultsUtils.writeTestSuiteResult(new TestSuiteResult(), resultFile);
+
+        assertTrue(resultFile.exists());
+
+        Files.delete(resultFile.toPath());
+        assertFalse(resultFile.exists());
     }
 
     @After


### PR DESCRIPTION
Hi,

Deleting suite XML file from allure-results directory fails with IO exception ("The process cannot access the file because it is being used by another process"). JAXB marshaller does not close the file Writer, it should be done explicitly. 

Thanks!