### PR TITLE
Use bundle to generate preview

### DIFF
--- a/allure-bundle/pom.xml
+++ b/allure-bundle/pom.xml
@@ -20,10 +20,13 @@
             <groupId>ru.yandex.qatools.allure</groupId>
             <artifactId>allure-report-data</artifactId>
         </dependency>
+
+        <!-- Add face with test scope to avoid it when using bundle in deps -->
         <dependency>
             <groupId>ru.yandex.qatools.allure</groupId>
             <artifactId>allure-report-face</artifactId>
             <type>war</type>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -35,7 +38,21 @@
                 <version>2.5.3</version>
                 <executions>
                     <execution>
-                        <id>allure-bundle-zip</id>
+                        <id>allure-bundle</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <finalName>allure-bundle-${project.version}</finalName>
+                            <appendAssemblyId>false</appendAssemblyId>
+                            <descriptors>
+                                <descriptor>src/assembly/bundle.xml</descriptor>
+                            </descriptors>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>allure-bundle-standalone</id>
                         <phase>package</phase>
                         <goals>
                             <goal>single</goal>
@@ -43,9 +60,8 @@
                         <configuration>
                             <finalName>allure-bundle-${project.version}</finalName>
                             <descriptors>
-                                <descriptor>src/assembly/bundle.xml</descriptor>
+                                <descriptor>src/assembly/standalone-bundle.xml</descriptor>
                             </descriptors>
-                            <appendAssemblyId>false</appendAssemblyId>
                             <archive>
                                 <manifest>
                                     <mainClass>ru.yandex.qatools.allure.AllureMain</mainClass>

--- a/allure-bundle/src/assembly/standalone-bundle.xml
+++ b/allure-bundle/src/assembly/standalone-bundle.xml
@@ -2,19 +2,18 @@
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
 
-    <id>bundle</id>
+    <id>standalone</id>
     <includeBaseDirectory>false</includeBaseDirectory>
     <formats>
         <format>jar</format>
     </formats>
 
     <dependencySets>
-        <!-- Only classes from the project-->
+        <!-- Add classes from the project and all dependencies -->
         <dependencySet>
             <useProjectArtifact>true</useProjectArtifact>
-            <unpack>true</unpack>
             <outputDirectory>/</outputDirectory>
-            <scope>none</scope>
+            <unpack>true</unpack>
         </dependencySet>
 
         <!-- Add allure-report-face war to resources with prefix `allure.report.face`-->

--- a/allure-commandline/pom.xml
+++ b/allure-commandline/pom.xml
@@ -94,6 +94,7 @@
                                     <artifactId>allure-bundle</artifactId>
                                     <version>${project.version}</version>
                                     <type>jar</type>
+                                    <classifier>standalone</classifier>
                                 </artifactItem>
                             </artifactItems>
                             <outputDirectory>${project.build.directory}/app</outputDirectory>

--- a/allure-report-preview/pom.xml
+++ b/allure-report-preview/pom.xml
@@ -22,11 +22,7 @@
     <dependencies>
         <dependency>
             <groupId>ru.yandex.qatools.allure</groupId>
-            <artifactId>allure-report-data</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-nop</artifactId>
+            <artifactId>allure-bundle</artifactId>
         </dependency>
     </dependencies>
 
@@ -54,24 +50,6 @@
                             </resources>
                         </configuration>
                     </execution>
-                    <execution>
-                        <id>copy-allure-report-face</id>
-                        <phase>generate-resources</phase>
-                        <goals>
-                            <goal>copy-resources</goal>
-                        </goals>
-                        <configuration>
-                            <outputDirectory>${allure.report.directory}</outputDirectory>
-                            <resources>
-                                <resource>
-                                    <directory>
-                                        ${project.parent.basedir}/allure-report-face/target/allure-report-face-${project.version}
-                                    </directory>
-                                    <filtering>false</filtering>
-                                </resource>
-                            </resources>
-                        </configuration>
-                    </execution>
                 </executions>
             </plugin>
             <plugin>
@@ -86,7 +64,7 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <mainClass>ru.yandex.qatools.allure.data.DummyReportGenerator</mainClass>
+                    <mainClass>ru.yandex.qatools.allure.AllureMain</mainClass>
                     <longClasspath>true</longClasspath>
                     <arguments>
                         <argument>${allure.results.directory}</argument>

--- a/pom.xml
+++ b/pom.xml
@@ -35,9 +35,9 @@
         <module>allure-report-plugin-api</module>
         <module>allure-report-data</module>
         <module>allure-report-face</module>
-        <module>allure-report-preview</module>
         <module>allure-bundle</module>
         <module>allure-commandline</module>
+        <module>allure-report-preview</module>
     </modules>
 
     <organization>
@@ -117,7 +117,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>exec-maven-plugin</artifactId>
-                    <version>1.3.2</version>
+                    <version>1.4.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.jvnet.jaxb2.maven2</groupId>
@@ -297,6 +297,11 @@
             <dependency>
                 <groupId>ru.yandex.qatools.allure</groupId>
                 <artifactId>allure-report-data</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ru.yandex.qatools.allure</groupId>
+                <artifactId>allure-commandline</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
* Move preview module to the end of the build cycle.
* Bundle now has `standalone` classifier for executable version (super jar). 
* Use bundle to generate preview