### PR TITLE
Correctly process step titles with "{this}"

### DIFF
--- a/allure-java-aspects/src/main/java/ru/yandex/qatools/allure/aspects/AllureAspectUtils.java
+++ b/allure-java-aspects/src/main/java/ru/yandex/qatools/allure/aspects/AllureAspectUtils.java
@@ -58,7 +58,7 @@ public final class AllureAspectUtils {
     public static String getTitle(String namePattern, String methodName, Object instance, Object[] parameters) {
         String finalPattern = namePattern
                 .replaceAll("\\{method\\}", methodName)
-                .replaceAll("\\{this\\}", String.valueOf(instance));
+                .replaceAll("\\{this\\}", getMessageFormatEscapedString(String.valueOf(instance)));
         int paramsCount = parameters == null ? 0 : parameters.length;
         Object[] results = new Object[paramsCount];
         for (int i = 0; i < paramsCount; i++) {
@@ -66,6 +66,12 @@ public final class AllureAspectUtils {
         }
 
         return cutEnd(MessageFormat.format(finalPattern, results), AllureConfig.newInstance().getMaxTitleLength());
+    }
+
+    public static String getMessageFormatEscapedString(String s) {
+        return s.replace("'", "''")
+                .replace("{", "'{'")
+                .replace("}", "'}'");
     }
 
     /**

--- a/allure-java-aspects/src/test/java/ru/yandex/qatools/allure/aspects/AllureAspectUtilsTest.java
+++ b/allure-java-aspects/src/test/java/ru/yandex/qatools/allure/aspects/AllureAspectUtilsTest.java
@@ -196,6 +196,15 @@ public class AllureAspectUtilsTest {
     }
 
     @Test
+    public void getTitleWithThisThatNeedsToBeEscaped() {
+        String thisObject = "{0}''";
+        String title = getTitle(NAME_PATTERN_WITH_THIS, METHOD_NAME, thisObject, new Object[]{1});
+        Object[] args = {METHOD_NAME, thisObject};
+        assertThat("Method with {this} that needs to be escaped is processed incorrectly", title,
+                equalTo(MessageFormat.format(TITLE_STRING_WITH_THIS, args)));
+    }
+
+    @Test
     public void getNameLongMethodNameTest() throws Exception {
         String name = getName(TOO_LONG_NAME, null);
         assertThat("Invalid method name short cut", name,


### PR DESCRIPTION
When I made the pull request that adds support for "{this}" in step titles (#350), I made a mistake which causes step titles to be processed incorrectly or even throw exception if "{this}" gets replaced by a string that contains MessageFormat control characters (single quote and curly braces). This pull request fixes it.