### PR TITLE
Downgrade jaxb plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
                 <plugin>
                     <groupId>org.jvnet.jaxb2.maven2</groupId>
                     <artifactId>maven-jaxb2-plugin</artifactId>
-                    <version>0.12.3</version>
+                    <version>0.10.0</version>
                     <executions>
                         <execution>
                             <goals>


### PR DESCRIPTION
Can't build `allure-core` at Windows, cause https://java.net/jira/browse/JAXB-1070 , so need to downgrade jaxb plugin