### PR TITLE
Add ability to process results in json format

### DIFF
--- a/allure-java-adaptor-api/src/main/java/ru/yandex/qatools/allure/utils/AllureResultsHelper.java
+++ b/allure-java-adaptor-api/src/main/java/ru/yandex/qatools/allure/utils/AllureResultsHelper.java
@@ -19,7 +19,7 @@ import java.util.regex.Pattern;
 
 import static org.apache.tika.mime.MimeTypes.getDefaultMimeTypes;
 import static ru.yandex.qatools.allure.AllureUtils.generateAttachmentName;
-import static ru.yandex.qatools.allure.AllureUtils.generateTestSuiteName;
+import static ru.yandex.qatools.allure.AllureUtils.generateTestSuiteXmlName;
 import static ru.yandex.qatools.allure.AllureUtils.marshalTestSuite;
 
 /**
@@ -161,7 +161,7 @@ public class AllureResultsHelper {
      * Shortcut for #writeTestSuiteResult(TestSuiteResult, File)
      */
     public void writeTestSuite(TestSuiteResult testSuite) {
-        marshalTestSuite(testSuite, resultsDirectory.resolve(generateTestSuiteName()));
+        marshalTestSuite(testSuite, resultsDirectory.resolve(generateTestSuiteXmlName()));
     }
 
     /**

--- a/allure-junit-adaptor/src/test/java/ru/yandex/qatools/allure/AllureListenerTimeoutTest.java
+++ b/allure-junit-adaptor/src/test/java/ru/yandex/qatools/allure/AllureListenerTimeoutTest.java
@@ -43,7 +43,7 @@ public class AllureListenerTimeoutTest extends BasicListenerTest {
     @Test
     public void shouldNotLoseEventsFromTestWithTimeout() throws Exception {
         TestSuiteResult result = JAXB.unmarshal(
-                AllureUtils.listTestSuiteFiles(resultsDirectory).iterator().next().toFile(),
+                AllureUtils.listTestSuiteXmlFiles(resultsDirectory).iterator().next().toFile(),
                 TestSuiteResult.class
         );
 

--- a/allure-junit-adaptor/src/test/java/ru/yandex/qatools/allure/AllureListenerXmlValidationTest.java
+++ b/allure-junit-adaptor/src/test/java/ru/yandex/qatools/allure/AllureListenerXmlValidationTest.java
@@ -11,7 +11,7 @@ import java.util.Collection;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
-import static ru.yandex.qatools.allure.AllureUtils.listTestSuiteFiles;
+import static ru.yandex.qatools.allure.AllureUtils.listTestSuiteXmlFiles;
 
 /**
  * @author Dmitry Baev charlie@yandex-team.ru
@@ -37,7 +37,7 @@ public class AllureListenerXmlValidationTest extends BasicListenerTest {
 
     @Test
     public void suiteFilesCountTest() throws Exception {
-        assertThat(listTestSuiteFiles(resultsDirectory).size(), is(1));
+        assertThat(listTestSuiteXmlFiles(resultsDirectory).size(), is(1));
     }
 
     @Test

--- a/allure-model/src/main/java/ru/yandex/qatools/allure/AllureConstants.java
+++ b/allure-model/src/main/java/ru/yandex/qatools/allure/AllureConstants.java
@@ -18,9 +18,14 @@ public final class AllureConstants {
     public static final String TEST_SUITE_FILE_SUFFIX = "-testsuite";
 
     /**
-     * The glob to find test suites in allure results.
+     * The glob to find xml test suites in allure results.
      */
-    public static final String TEST_SUITE_FILE_GLOB = String.format("*%s.xml", TEST_SUITE_FILE_SUFFIX);
+    public static final String TEST_SUITE_XML_FILE_GLOB = String.format("*%s.xml", TEST_SUITE_FILE_SUFFIX);
+
+    /**
+     * The glob to find json test suites in allure results.
+     */
+    public static final String TEST_SUITE_JSON_FILE_GLOB = String.format("*%s.json", TEST_SUITE_FILE_SUFFIX);
 
     /**
      * The suffix of attachment files. All attachments should has such suffix.

--- a/allure-model/src/main/java/ru/yandex/qatools/allure/AllureUtils.java
+++ b/allure-model/src/main/java/ru/yandex/qatools/allure/AllureUtils.java
@@ -35,6 +35,8 @@ import static javax.xml.bind.Marshaller.JAXB_ENCODING;
 import static javax.xml.bind.Marshaller.JAXB_FORMATTED_OUTPUT;
 import static ru.yandex.qatools.allure.AllureConstants.ATTACHMENTS_FILE_SUFFIX;
 import static ru.yandex.qatools.allure.AllureConstants.TEST_SUITE_FILE_SUFFIX;
+import static ru.yandex.qatools.allure.AllureConstants.TEST_SUITE_JSON_FILE_GLOB;
+import static ru.yandex.qatools.allure.AllureConstants.TEST_SUITE_XML_FILE_GLOB;
 
 /**
  * @author Dmitry Baev charlie@yandex-team.ru
@@ -65,8 +67,17 @@ public final class AllureUtils {
      *
      * @return test suite file name
      */
-    public static String generateTestSuiteName() {
+    public static String generateTestSuiteXmlName() {
         return String.format("%s%s.xml", UUID.randomUUID().toString(), TEST_SUITE_FILE_SUFFIX);
+    }
+
+    /**
+     * Generate suite file name \"{randomUid}-testsutie.json\"
+     *
+     * @return test suite file name
+     */
+    public static String generateTestSuiteJsonName() {
+        return String.format("%s%s.json", UUID.randomUUID().toString(), TEST_SUITE_FILE_SUFFIX);
     }
 
     /**
@@ -121,12 +132,21 @@ public final class AllureUtils {
     }
 
     /**
-     * Find all test suite files in specified directories.
+     * Find all xml test suite files in specified directories.
      *
      * @see #listFiles(String, Path...)
      */
-    public static List<Path> listTestSuiteFiles(Path... directories) throws IOException {
-        return listFiles(AllureConstants.TEST_SUITE_FILE_GLOB, directories);
+    public static List<Path> listTestSuiteXmlFiles(Path... directories) throws IOException {
+        return listFiles(TEST_SUITE_XML_FILE_GLOB, directories);
+    }
+
+    /**
+     * Find all json test suite files in specified directories.
+     *
+     * @see #listFiles(String, Path...)
+     */
+    public static List<Path> listTestSuiteJsonFiles(Path... directories) throws IOException {
+        return listFiles(TEST_SUITE_JSON_FILE_GLOB, directories);
     }
 
     /**
@@ -170,7 +190,7 @@ public final class AllureUtils {
     /**
      * Marshal {@link ru.yandex.qatools.allure.model.TestSuiteResult} to specified file
      * uses {@link BadXmlCharacterFilterWriter}. Name of file generated uses
-     * {@link #generateTestSuiteName()}
+     * {@link #generateTestSuiteXmlName()}
      *
      * @param testSuite to marshal
      */
@@ -267,7 +287,7 @@ public final class AllureUtils {
     public static void validateResults(Path... directories) {
         try {
             Validator validator = getSchemaValidator();
-            for (Path suite : listTestSuiteFiles(directories)) {
+            for (Path suite : listTestSuiteXmlFiles(directories)) {
                 validator.validate(new StreamSource(suite.toFile()));
             }
         } catch (SAXException | IOException e) {

--- a/allure-model/src/test/java/ru/yandex/qatools/allure/AllureUtilsTest.java
+++ b/allure-model/src/test/java/ru/yandex/qatools/allure/AllureUtilsTest.java
@@ -15,7 +15,7 @@ import java.nio.file.Path;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static ru.yandex.qatools.allure.AllureUtils.generateTestSuiteName;
+import static ru.yandex.qatools.allure.AllureUtils.generateTestSuiteXmlName;
 import static ru.yandex.qatools.allure.AllureUtils.marshalTestSuite;
 import static ru.yandex.qatools.allure.AllureUtils.validateResults;
 import static ru.yandex.qatools.allure.Matchers.exists;
@@ -44,7 +44,7 @@ public class AllureUtilsTest {
 
     @Test
     public void shouldEscapeBadCharactersWhileMarshal() throws Exception {
-        Path suite = resultsDirectory.resolve(generateTestSuiteName());
+        Path suite = resultsDirectory.resolve(generateTestSuiteXmlName());
         marshalTestSuite(new TestSuiteResult().withName("hi\uFFFEme"), suite);
         validateResults(resultsDirectory);
         TestSuiteResult result = JAXB.unmarshal(suite.toFile(), TestSuiteResult.class);
@@ -53,7 +53,7 @@ public class AllureUtilsTest {
 
     @Test
     public void shouldCloseTestSuiteFile() throws Exception {
-        Path suite = resultsDirectory.resolve(generateTestSuiteName());
+        Path suite = resultsDirectory.resolve(generateTestSuiteXmlName());
         marshalTestSuite(new TestSuiteResult(), suite);
 
         assertThat(suite, exists());

--- a/allure-model/src/test/resources/allure-results/sample-json-testsuite.json
+++ b/allure-model/src/test/resources/allure-results/sample-json-testsuite.json
@@ -1,0 +1,30 @@
+{
+  "name": "other.PassingTest",
+  "start": 1412949538848,
+  "stop": 1412949560045,
+  "version": "1.4.4-SNAPSHOT",
+  "testCases": [
+    {
+      "name": "testPassed",
+      "start": 1412949529363,
+      "stop": 1412949549730,
+      "status": "PASSED",
+      "labels": [
+        {
+          "name": "issue",
+          "value": "JIRA-15"
+        },
+        {
+          "name": "testId",
+          "value": "TMS-1"
+        }
+      ]
+    }
+  ],
+  "labels": [
+    {
+      "name": "story",
+      "value": "SuccessStory"
+    }
+  ]
+}

--- a/allure-report-data/pom.xml
+++ b/allure-report-data/pom.xml
@@ -143,7 +143,7 @@
         <!--groovy-->
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy</artifactId>
+            <artifactId>groovy-all</artifactId>
             <version>${groovy.version}</version>
             <classifier>indy</classifier>
         </dependency>

--- a/allure-report-data/src/main/java/ru/yandex/qatools/allure/io/AbstractResultIterator.java
+++ b/allure-report-data/src/main/java/ru/yandex/qatools/allure/io/AbstractResultIterator.java
@@ -1,0 +1,74 @@
+package ru.yandex.qatools.allure.io;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+import static ru.yandex.qatools.allure.AllureUtils.listFiles;
+
+/**
+ * @author Dmitry Baev charlie@yandex-team.ru
+ *         Date: 08.10.15
+ */
+public abstract class AbstractResultIterator<T> implements Iterator<T> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractResultIterator.class);
+
+    private final Iterator<Path> files;
+
+    /**
+     * Creates an instance of iterator.
+     */
+    public AbstractResultIterator(Path... resultDirectories) throws IOException {
+        files = listFiles(getFilesGlob(), resultDirectories).iterator();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean hasNext() {
+        return files.hasNext();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public T next() {
+        if (!files.hasNext()) {
+            throw new NoSuchElementException();
+        }
+        Path next = files.next();
+        try {
+            return readResult(next);
+        } catch (IOException e) {
+            LOGGER.warn(String.format("Could not read <%s> file", next.toAbsolutePath().toString()), e);
+            return next();
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void remove() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Read result from given path.
+     *
+     * @throws IOException if any occurs.
+     */
+    protected abstract T readResult(Path path) throws IOException;
+
+    /**
+     * Returns the glob for files to read.
+     */
+    protected abstract String getFilesGlob();
+}

--- a/allure-report-data/src/main/java/ru/yandex/qatools/allure/io/JsonTestSuiteResultIterator.java
+++ b/allure-report-data/src/main/java/ru/yandex/qatools/allure/io/JsonTestSuiteResultIterator.java
@@ -1,0 +1,46 @@
+package ru.yandex.qatools.allure.io;
+
+import ru.yandex.qatools.allure.model.TestSuiteResult;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static ru.yandex.qatools.allure.AllureConstants.TEST_SUITE_JSON_FILE_GLOB;
+import static ru.yandex.qatools.allure.utils.AllureReportUtils.createMapperWithJaxbAnnotationInspector;
+
+/**
+ * @author Dmitry Baev charlie@yandex-team.ru
+ *         Date: 08.10.15
+ */
+public class JsonTestSuiteResultIterator extends AbstractResultIterator<TestSuiteResult> {
+
+    /**
+     * Creates an instance of iterator.
+     */
+    public JsonTestSuiteResultIterator(Path... resultDirectories) throws IOException {
+        super(resultDirectories);
+    }
+
+    /**
+     * Read JSON test suite result.
+     * <p/>
+     * {@inheritDoc}
+     */
+    @Override
+    protected TestSuiteResult readResult(Path path) throws IOException {
+        try (InputStream is = Files.newInputStream(path)) {
+            return createMapperWithJaxbAnnotationInspector()
+                    .readValue(is, TestSuiteResult.class);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected String getFilesGlob() {
+        return TEST_SUITE_JSON_FILE_GLOB;
+    }
+}

--- a/allure-report-data/src/main/java/ru/yandex/qatools/allure/io/TestCaseReader.java
+++ b/allure-report-data/src/main/java/ru/yandex/qatools/allure/io/TestCaseReader.java
@@ -1,14 +1,10 @@
 package ru.yandex.qatools.allure.io;
 
 import com.google.inject.Inject;
-import ru.yandex.qatools.allure.model.Label;
 import ru.yandex.qatools.allure.model.TestCaseResult;
 import ru.yandex.qatools.allure.model.TestSuiteResult;
-import ru.yandex.qatools.allure.model.Description;
 
 import java.util.Iterator;
-
-import static ru.yandex.qatools.allure.utils.DescriptionUtils.mergeDescriptions;
 
 /**
  * @author Dmitry Baev charlie@yandex-team.ru
@@ -19,61 +15,15 @@ public class TestCaseReader implements Reader<TestCaseResult> {
     public static final String SUITE_NAME = "suite-name";
     public static final String SUITE_TITLE = "suite-title";
 
-    private Iterator<TestSuiteResult> testSuites;
-
-    private Iterator<TestCaseResult> testCases;
-
-    private TestSuiteResult currentSuite;
+    private final Reader<TestSuiteResult> testSuites;
 
     @Inject
     public TestCaseReader(Reader<TestSuiteResult> suiteResultsReader) {
-        testSuites = suiteResultsReader.iterator();
+        testSuites = suiteResultsReader;
     }
 
     @Override
     public Iterator<TestCaseResult> iterator() {
-        return new TestCaseResultIterator();
-    }
-
-    private class TestCaseResultIterator implements Iterator<TestCaseResult> {
-
-        private boolean nextSuite() {
-            if ((testCases == null || !testCases.hasNext()) && testSuites.hasNext()) {
-
-                currentSuite = testSuites.next();
-                testCases = currentSuite.getTestCases().iterator();
-
-                return true;
-            }
-            return false;
-        }
-
-        @Override
-        public boolean hasNext() {
-            return testCases != null && testCases.hasNext() || nextSuite() && hasNext();
-        }
-
-        @Override
-        public TestCaseResult next() {
-            if (!hasNext()) {
-                return null;
-            }
-
-            TestCaseResult result = testCases.next();
-
-            result.getLabels().add(new Label().withName(SUITE_NAME).withValue(currentSuite.getName()));
-            result.getLabels().add(new Label().withName(SUITE_TITLE).withValue(currentSuite.getTitle()));
-            result.getLabels().addAll(currentSuite.getLabels());
-            Description description = mergeDescriptions(currentSuite, result);
-            result.setDescription(description);
-
-            return result;
-        }
-
-        @Override
-        public void remove() {
-            throw new UnsupportedOperationException();
-        }
-
+        return new TestCaseResultIterator2(testSuites);
     }
 }

--- a/allure-report-data/src/main/java/ru/yandex/qatools/allure/io/TestCaseResultIterator.java
+++ b/allure-report-data/src/main/java/ru/yandex/qatools/allure/io/TestCaseResultIterator.java
@@ -1,0 +1,69 @@
+package ru.yandex.qatools.allure.io;
+
+import ru.yandex.qatools.allure.model.Label;
+import ru.yandex.qatools.allure.model.TestCaseResult;
+import ru.yandex.qatools.allure.model.TestSuiteResult;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+import static ru.yandex.qatools.allure.io.TestCaseReader.SUITE_NAME;
+import static ru.yandex.qatools.allure.io.TestCaseReader.SUITE_TITLE;
+import static ru.yandex.qatools.allure.utils.DescriptionUtils.mergeDescriptions;
+
+/**
+ * @author Dmitry Baev charlie@yandex-team.ru
+ *         Date: 08.10.15
+ */
+public class TestCaseResultIterator implements Iterator<TestCaseResult> {
+
+    private final TestSuiteResult testSuite;
+
+    private final Iterator<TestCaseResult> iterator;
+
+    private final Label suiteNameLabel;
+
+    private final Label suiteTitleLabel;
+
+    public TestCaseResultIterator(TestSuiteResult testSuite) {
+        this.testSuite = testSuite;
+        this.iterator = testSuite.getTestCases().iterator();
+        this.suiteNameLabel = new Label().withName(SUITE_NAME).withValue(testSuite.getName());
+        this.suiteTitleLabel = new Label().withName(SUITE_TITLE).withValue(testSuite.getTitle());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean hasNext() {
+        return iterator.hasNext();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public TestCaseResult next() {
+        if (!hasNext()) {
+            throw new NoSuchElementException();
+        }
+
+        TestCaseResult result = iterator.next();
+
+        result.getLabels().add(suiteNameLabel);
+        result.getLabels().add(suiteTitleLabel);
+        result.getLabels().addAll(testSuite.getLabels());
+        result.setDescription(mergeDescriptions(testSuite, result));
+
+        return result;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void remove() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/allure-report-data/src/main/java/ru/yandex/qatools/allure/io/TestCaseResultIterator2.java
+++ b/allure-report-data/src/main/java/ru/yandex/qatools/allure/io/TestCaseResultIterator2.java
@@ -1,0 +1,60 @@
+package ru.yandex.qatools.allure.io;
+
+import com.google.common.collect.ImmutableSet;
+import ru.yandex.qatools.allure.model.TestCaseResult;
+import ru.yandex.qatools.allure.model.TestSuiteResult;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+/**
+ * @author Dmitry Baev charlie@yandex-team.ru
+ *         Date: 08.10.15
+ */
+public class TestCaseResultIterator2 implements Iterator<TestCaseResult> {
+
+    private final Iterator<TestSuiteResult> testSuites;
+
+    private Iterator<TestCaseResult> current = ImmutableSet.<TestCaseResult>of().iterator();
+
+    public TestCaseResultIterator2(Reader<TestSuiteResult> testSuites) {
+        this.testSuites = testSuites.iterator();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean hasNext() {
+        if (current.hasNext()) {
+            return true;
+        }
+
+        if (!testSuites.hasNext()) {
+            return false;
+        }
+
+        current = new TestCaseResultIterator(testSuites.next());
+        return hasNext();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public TestCaseResult next() {
+        if (!hasNext()) {
+            throw new NoSuchElementException();
+        }
+
+        return current.next();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void remove() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/allure-report-data/src/main/java/ru/yandex/qatools/allure/io/XmlTestSuiteResultIterator.java
+++ b/allure-report-data/src/main/java/ru/yandex/qatools/allure/io/XmlTestSuiteResultIterator.java
@@ -1,0 +1,41 @@
+package ru.yandex.qatools.allure.io;
+
+import ru.yandex.qatools.allure.model.TestSuiteResult;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static ru.yandex.qatools.allure.AllureConstants.TEST_SUITE_XML_FILE_GLOB;
+import static ru.yandex.qatools.allure.AllureUtils.unmarshalTestSuite;
+
+/**
+ * @author Dmitry Baev charlie@yandex-team.ru
+ *         Date: 08.10.15
+ */
+public class XmlTestSuiteResultIterator extends AbstractResultIterator<TestSuiteResult> {
+
+    /**
+     * Creates an instance of iterator.
+     */
+    public XmlTestSuiteResultIterator(Path... resultDirectories) throws IOException {
+        super(resultDirectories);
+    }
+
+    /**
+     * Read XML test suite result.
+     * <p/>
+     * {@inheritDoc}
+     */
+    @Override
+    protected TestSuiteResult readResult(Path path) throws IOException {
+        return unmarshalTestSuite(path);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected String getFilesGlob() {
+        return TEST_SUITE_XML_FILE_GLOB;
+    }
+}

--- a/allure-report-data/src/test/groovy/ru/yandex/qatools/allure/io/TestCaseReaderTest.groovy
+++ b/allure-report-data/src/test/groovy/ru/yandex/qatools/allure/io/TestCaseReaderTest.groovy
@@ -11,6 +11,7 @@ import ru.yandex.qatools.allure.utils.PluginUtils
 
 import java.nio.file.Paths
 
+import static groovy.test.GroovyAssert.shouldFail
 import static org.hamcrest.MatcherAssert.assertThat
 import static org.hamcrest.Matchers.equalTo
 import static ru.yandex.qatools.allure.utils.DescriptionUtils.mergeDescriptions
@@ -24,16 +25,26 @@ class TestCaseReaderTest {
     @Test
     void shouldNotHasNextIfNotHasSuiteResult() {
         def reader = getReader([]);
-        assert !reader.iterator().hasNext()
-        assert reader.iterator().next() == null
+
+        def iterator = reader.iterator()
+        assert !iterator.hasNext()
+
+        shouldFail(NoSuchElementException, {
+            iterator.next()
+        })
     }
 
     @Test
     void shouldNotHasNextIfNotHasTestCaseResult() {
         def testSuite = new TestSuiteResult(name: "name")
         def reader = getReader([testSuite]);
-        assert !reader.iterator().hasNext()
-        assert reader.iterator().next() == null
+
+        def iterator = reader.iterator()
+        assert !iterator.hasNext()
+
+        shouldFail(NoSuchElementException, {
+            iterator.next()
+        })
     }
 
     @Test
@@ -41,9 +52,11 @@ class TestCaseReaderTest {
         def testCase = new TestCaseResult(name: "testCase")
         def testSuite = new TestSuiteResult(name: "name", testCases: [testCase])
         def reader = getReader([testSuite]);
-        assert reader.iterator().hasNext()
-        assert reader.iterator().next() == testCase
-        assert !reader.iterator().hasNext()
+
+        def iterator = reader.iterator()
+        assert iterator.hasNext()
+        assert iterator.next() == testCase
+        assert !iterator.hasNext()
     }
 
     @Test
@@ -53,11 +66,13 @@ class TestCaseReaderTest {
         def testSuite1 = new TestSuiteResult(name: "name1", testCases: [testCase1])
         def testSuite2 = new TestSuiteResult(name: "name2", testCases: [testCase2])
         def reader = getReader([testSuite1, testSuite2]);
-        assert reader.iterator().hasNext()
-        assert reader.iterator().next() == testCase1
-        assert reader.iterator().hasNext()
-        assert reader.iterator().next() == testCase2
-        assert !reader.iterator().hasNext()
+
+        def iterator = reader.iterator()
+        assert iterator.hasNext()
+        assert iterator.next() == testCase1
+        assert iterator.hasNext()
+        assert iterator.next() == testCase2
+        assert !iterator.hasNext()
     }
 
     @Ignore("Feature don't implemented. Seems like it's redundant logic")
@@ -68,11 +83,13 @@ class TestCaseReaderTest {
         def testSuite1 = new TestSuiteResult(name: "name1", testCases: [testCase1])
         def testSuite2 = new TestSuiteResult(name: "name2", testCases: [testCase2])
         def reader = getReader([testSuite1, null, testSuite2]);
-        assert reader.iterator().hasNext()
-        assert reader.iterator().next() == testCase1
-        assert reader.iterator().hasNext()
-        assert reader.iterator().next() == testCase2
-        assert !reader.iterator().hasNext()
+
+        def iterator = reader.iterator()
+        assert iterator.hasNext()
+        assert iterator.next() == testCase1
+        assert iterator.hasNext()
+        assert iterator.next() == testCase2
+        assert !iterator.hasNext()
     }
 
     @Test
@@ -81,9 +98,11 @@ class TestCaseReaderTest {
         def testSuite1 = new TestSuiteResult(name: "name1", testCases: [])
         def testSuite2 = new TestSuiteResult(name: "name2", testCases: [testCase])
         def reader = getReader([testSuite1, testSuite2]);
-        assert reader.iterator().hasNext()
-        assert reader.iterator().next() == testCase
-        assert !reader.iterator().hasNext()
+
+        def iterator = reader.iterator()
+        assert iterator.hasNext()
+        assert iterator.next() == testCase
+        assert !iterator.hasNext()
     }
 
     @Test
@@ -95,7 +114,9 @@ class TestCaseReaderTest {
 
         def reader = getReader([testSuite]);
 
-        def next = reader.iterator().next()
+
+        def iterator = reader.iterator()
+        def next = iterator.next()
         use(PluginUtils) {
             assert next
             assert next.getSuiteName() == "name"
@@ -104,13 +125,16 @@ class TestCaseReaderTest {
         }
     }
 
-    @Test(expected = UnsupportedOperationException)
+    @Test
     void shouldNotRemoveFromIterator() {
         def testCase = new TestCaseResult(name: "testCase")
         def testSuite = new TestSuiteResult(name: "name", testCases: [testCase])
 
-        def reader = getReader([testSuite]);
-        reader.iterator().remove()
+        def reader = getReader([testSuite])
+
+        shouldFail(UnsupportedOperationException, {
+            reader.iterator().remove()
+        })
     }
 
     @Test

--- a/allure-report-data/src/test/groovy/ru/yandex/qatools/allure/io/TestSuiteReaderTest.groovy
+++ b/allure-report-data/src/test/groovy/ru/yandex/qatools/allure/io/TestSuiteReaderTest.groovy
@@ -6,10 +6,13 @@ import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import ru.yandex.qatools.allure.model.ObjectFactory
 import ru.yandex.qatools.allure.model.TestSuiteResult
+import ru.yandex.qatools.allure.utils.AllureReportUtils
 
 import javax.xml.bind.JAXB
 
-import static ru.yandex.qatools.allure.AllureUtils.generateTestSuiteName
+import static groovy.test.GroovyAssert.shouldFail
+import static ru.yandex.qatools.allure.AllureUtils.generateTestSuiteJsonName
+import static ru.yandex.qatools.allure.AllureUtils.generateTestSuiteXmlName
 
 /**
  * @author Dmitry Baev charlie@yandex-team.ru
@@ -22,26 +25,36 @@ class TestSuiteReaderTest {
 
     @Test
     void shouldNotHasNextIfNotHasSuiteResult() {
-        def reader = getReader([]);
-        assert !reader.iterator().hasNext()
-        assert reader.iterator().next() == null
+        def reader = getReader([])
+
+        def iterator = reader.iterator()
+        assert !iterator.hasNext()
+        shouldFail(NoSuchElementException, {
+            iterator.next()
+        })
     }
 
     @Test
     void shouldHasNextIfHas() {
         def testSuite = new TestSuiteResult(name: "name")
         def reader = getReader([testSuite]);
-        assert reader.iterator().hasNext()
-        assert reader.iterator().next() == testSuite
-        assert !reader.iterator().hasNext()
+
+        def iterator = reader.iterator()
+        assert iterator.hasNext()
+        assert iterator.next() == testSuite
+        assert !iterator.hasNext()
     }
 
-    @Test(expected = UnsupportedOperationException)
+    @Test
     void shouldNotRemoveFromIterator() {
         def testSuite = new TestSuiteResult(name: "name")
 
-        def reader = getReader([testSuite]);
-        reader.iterator().remove()
+        def reader = getReader([testSuite])
+        def iterator = reader.iterator()
+        iterator.next()
+        shouldFail(UnsupportedOperationException, {
+            iterator.remove()
+        })
     }
 
     @Test
@@ -49,21 +62,36 @@ class TestSuiteReaderTest {
         def dir = folder.newFolder()
         def testSuite = new TestSuiteResult(name: "name")
 
-        def file = new File(dir, generateTestSuiteName())
+        def file = new File(dir, generateTestSuiteXmlName())
         JAXB.marshal(new ObjectFactory().createTestSuite(testSuite), file)
 
         def reader = new TestSuiteReader(dir.toPath())
         FileUtils.deleteQuietly(file)
 
-        assert reader.iterator().hasNext()
-        assert reader.iterator().next() == null
-        assert !reader.iterator().hasNext()
+
+        def iterator = reader.iterator()
+        assert !iterator.hasNext()
+    }
+
+    @Test
+    void shouldReadJsonFilesAsWell() {
+        def testSuite = new TestSuiteResult(name: "name")
+        def dir = folder.newFolder()
+        AllureReportUtils.serialize(dir, generateTestSuiteJsonName(), testSuite)
+
+        def reader = new TestSuiteReader(dir.toPath())
+
+
+        def iterator = reader.iterator()
+        assert iterator.hasNext()
+        assert iterator.next() == testSuite
+        assert !iterator.hasNext()
     }
 
     def getReader(List<TestSuiteResult> results) {
         def dir = folder.newFolder();
         for (def result : results) {
-            JAXB.marshal(new ObjectFactory().createTestSuite(result), new File(dir, generateTestSuiteName()))
+            JAXB.marshal(new ObjectFactory().createTestSuite(result), new File(dir, generateTestSuiteXmlName()))
         }
 
         new TestSuiteReader(dir.toPath())

--- a/allure-report-data/src/test/java/ru/yandex/qatools/allure/AllureReportGeneratorTest.java
+++ b/allure-report-data/src/test/java/ru/yandex/qatools/allure/AllureReportGeneratorTest.java
@@ -10,8 +10,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static ru.yandex.qatools.allure.AllureUtils.listAttachmentFiles;
@@ -45,8 +44,8 @@ public class AllureReportGeneratorTest {
         assertThat(dataDirectory, contains(PluginManager.WIDGETS_JSON));
         assertThat(dataDirectory, contains(ReportWriter.REPORT_JSON));
 
-        assertThat(listAttachmentFiles(dataDirectory), not(empty()));
-        assertThat(listFiles("*-testcase.json", dataDirectory), not(empty()));
+        assertThat(listAttachmentFiles(dataDirectory), hasSize(12));
+        assertThat(listFiles("*-testcase.json", dataDirectory), hasSize(320));
     }
 
     @Test(expected = ReportGenerationException.class)

--- a/allure-testng-adaptor/src/test/java/ru/yandex/qatools/allure/AllureTestListenerConfigMethodsTest.java
+++ b/allure-testng-adaptor/src/test/java/ru/yandex/qatools/allure/AllureTestListenerConfigMethodsTest.java
@@ -19,7 +19,7 @@ import java.util.List;
 
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertThat;
-import static ru.yandex.qatools.allure.AllureUtils.listTestSuiteFiles;
+import static ru.yandex.qatools.allure.AllureUtils.listTestSuiteXmlFiles;
 
 /**
  * Test for various TestNg configuration method skip behavior
@@ -54,7 +54,7 @@ public class AllureTestListenerConfigMethodsTest extends BasicListenerTest {
 
     @Test
     public void validateCanceledTest() throws IOException {
-        for (Path file : listTestSuiteFiles(resultsDirectory)) {
+        for (Path file : listTestSuiteXmlFiles(resultsDirectory)) {
             TestSuiteResult result = JAXB.unmarshal(file.toFile(), TestSuiteResult.class);
             validateTestSuiteResult(result);
         }

--- a/allure-testng-adaptor/src/test/java/ru/yandex/qatools/allure/AllureTestListenerMultipleSuitesTest.java
+++ b/allure-testng-adaptor/src/test/java/ru/yandex/qatools/allure/AllureTestListenerMultipleSuitesTest.java
@@ -13,7 +13,7 @@ import java.util.List;
 
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertThat;
-import static ru.yandex.qatools.allure.AllureUtils.listTestSuiteFiles;
+import static ru.yandex.qatools.allure.AllureUtils.listTestSuiteXmlFiles;
 import static ru.yandex.qatools.allure.AllureUtils.validateResults;
 
 /**
@@ -36,7 +36,7 @@ public class AllureTestListenerMultipleSuitesTest extends BasicListenerTest {
 
     @Test
     public void suiteFilesCountTest() throws Exception {
-        assertThat(listTestSuiteFiles(resultsDirectory).size(), equalTo(2));
+        assertThat(listTestSuiteXmlFiles(resultsDirectory).size(), equalTo(2));
     }
 
     @Test
@@ -47,7 +47,7 @@ public class AllureTestListenerMultipleSuitesTest extends BasicListenerTest {
     @Test
     public void validatePendingTest() throws IOException {
         TestSuiteResult testSuite = JAXB.unmarshal(
-                AllureUtils.listTestSuiteFiles(resultsDirectory).iterator().next().toFile(),
+                AllureUtils.listTestSuiteXmlFiles(resultsDirectory).iterator().next().toFile(),
                 TestSuiteResult.class
         );
 

--- a/allure-testng-adaptor/src/test/java/ru/yandex/qatools/allure/AllureTestListenerSuiteNameTest.java
+++ b/allure-testng-adaptor/src/test/java/ru/yandex/qatools/allure/AllureTestListenerSuiteNameTest.java
@@ -1,8 +1,6 @@
 package ru.yandex.qatools.allure;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 import org.testng.TestNG;
 import ru.yandex.qatools.allure.model.TestSuiteResult;
 
@@ -17,7 +15,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assume.assumeThat;
-import static ru.yandex.qatools.allure.AllureUtils.listTestSuiteFiles;
+import static ru.yandex.qatools.allure.AllureUtils.listTestSuiteXmlFiles;
 
 /**
  * @author Dmitry Baev charlie@yandex-team.ru
@@ -38,7 +36,7 @@ public class AllureTestListenerSuiteNameTest extends BasicListenerTest {
 
     @Test
     public void shouldContainsBothSuitesWithDifferentNames() throws Exception {
-        Collection<Path> files = listTestSuiteFiles(resultsDirectory);
+        Collection<Path> files = listTestSuiteXmlFiles(resultsDirectory);
         assumeThat(files, hasSize(2));
         List<String> names = new ArrayList<>();
         for (Path file : files) {

--- a/allure-testng-adaptor/src/test/java/ru/yandex/qatools/allure/AllureTestListenerXmlValidationTest.java
+++ b/allure-testng-adaptor/src/test/java/ru/yandex/qatools/allure/AllureTestListenerXmlValidationTest.java
@@ -6,7 +6,7 @@ import ru.yandex.qatools.allure.testdata.TestDataClass;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
-import static ru.yandex.qatools.allure.AllureUtils.listTestSuiteFiles;
+import static ru.yandex.qatools.allure.AllureUtils.listTestSuiteXmlFiles;
 import static ru.yandex.qatools.allure.AllureUtils.validateResults;
 
 /**
@@ -17,7 +17,7 @@ public class AllureTestListenerXmlValidationTest extends BasicListenerTest {
 
     @Test
     public void suiteFilesCountTest() throws Exception {
-        assertThat(listTestSuiteFiles(resultsDirectory).size(), is(1));
+        assertThat(listTestSuiteXmlFiles(resultsDirectory).size(), is(1));
     }
 
     @Test


### PR DESCRIPTION
### Now you can use `json` instead `xml` for Allure results

```json
{
  "name": "other.PassingTest",
  "start": 1412949538848,
  "stop": 1412949560045,
  "version": "1.4.4-SNAPSHOT",
  "testCases": [
    {
      "name": "testPassed",
      "start": 1412949529363,
      "stop": 1412949549730,
      "status": "PASSED",
      "labels": [
        {
          "name": "issue",
          "value": "JIRA-15"
        },
        {
          "name": "testId",
          "value": "TMS-1"
        }
      ]
    }
  ],
  "labels": [
    {
      "name": "story",
      "value": "SuccessStory"
    }
  ]
}
```