### PR TITLE
Feature: disable testng parameters rendering

### DIFF
--- a/allure-model/src/main/java/ru/yandex/qatools/allure/config/AllureConfig.java
+++ b/allure-model/src/main/java/ru/yandex/qatools/allure/config/AllureConfig.java
@@ -70,6 +70,9 @@ public class AllureConfig {
     @Property("allure.tests.management.pattern")
     protected String tmsPattern = "%s";
 
+    @Property("allure.testng.parameters.enabled")
+    protected boolean testNgParametersEnabled = true;
+
     protected String version = getClass().getPackage().getImplementationVersion();
 
     public AllureConfig() {
@@ -134,6 +137,10 @@ public class AllureConfig {
 
     public String getTmsPattern() {
         return tmsPattern;
+    }
+
+    public boolean areTestNgParametersEnabled() {
+        return testNgParametersEnabled;
     }
 
     public String getVersion() {

--- a/allure-testng-adaptor/src/main/java/ru/yandex/qatools/allure/testng/AllureTestListener.java
+++ b/allure-testng-adaptor/src/main/java/ru/yandex/qatools/allure/testng/AllureTestListener.java
@@ -10,6 +10,7 @@ import org.testng.ITestResult;
 import org.testng.internal.IResultListener;
 import ru.yandex.qatools.allure.Allure;
 import ru.yandex.qatools.allure.annotations.Parameter;
+import ru.yandex.qatools.allure.config.AllureConfig;
 import ru.yandex.qatools.allure.config.AllureModelUtils;
 import ru.yandex.qatools.allure.events.AddParameterEvent;
 import ru.yandex.qatools.allure.events.TestCaseCanceledEvent;
@@ -140,7 +141,10 @@ public class AllureTestListener implements IResultListener, ISuiteListener {
         am.update(event);
 
         getLifecycle().fire(event);
-        fireAddParameterEvents(iTestResult);
+
+        if (AllureConfig.newInstance().areTestNgParametersEnabled()) {
+            fireAddParameterEvents(iTestResult);
+        }
     }
 
     @Override
@@ -212,7 +216,8 @@ public class AllureTestListener implements IResultListener, ISuiteListener {
         String xmlTest = iTestContext.getCurrentXmlTest().getName();
         String params = "";
 
-        if (!iTestContext.getCurrentXmlTest().getLocalParameters().isEmpty()) {
+        if (!iTestContext.getCurrentXmlTest().getLocalParameters().isEmpty() &&
+                AllureConfig.newInstance().areTestNgParametersEnabled()) {
             params = iTestContext.getCurrentXmlTest().getLocalParameters()
                     .toString().replace("{", "[").replace("}", "]");
         }
@@ -224,14 +229,18 @@ public class AllureTestListener implements IResultListener, ISuiteListener {
         String suitePrefix = getCurrentSuitePrefix(iTestResult);
         StringBuilder sb = new StringBuilder(suitePrefix);
         sb.append(iTestResult.getName());
-        Object[] parameters = iTestResult.getParameters();
-        if (parameters != null && parameters.length > 0) {
-            sb.append("[");
-            for (Object parameter : parameters) {
-                sb.append(parameter).append(",");
+
+        if (AllureConfig.newInstance().areTestNgParametersEnabled()) {
+            Object[] parameters = iTestResult.getParameters();
+            if (parameters != null && parameters.length > 0) {
+                sb.append("[");
+                for (Object parameter : parameters) {
+                    sb.append(parameter).append(",");
+                }
+                sb.replace(sb.length() - 1, sb.length(), "]");
             }
-            sb.replace(sb.length() - 1, sb.length(), "]");
         }
+
         return sb.toString();
     }
 


### PR DESCRIPTION
Proposal request: for users, who has lots of parameters (in suite xml) or heavy entities (produced e.g. by DataProvider) in tests, it's quite annoying to see all of them in every report's title (suite name, testcase name, test headers).

In the following PR there was introduced a new property **allure.are.testng.parameters.disabled**, which is **false** by default to avoid any issues for existing users. But if someone wants to disable parameters rendering, he could just set corresponding property = **true**.