### PR TITLE
Feature: new range placeholders

### DIFF
--- a/allure-java-aspects/src/test/java/ru/yandex/qatools/allure/aspects/AllureAspectUtilsTest.java
+++ b/allure-java-aspects/src/test/java/ru/yandex/qatools/allure/aspects/AllureAspectUtilsTest.java
@@ -33,7 +33,15 @@ public class AllureAspectUtilsTest {
 
     private final static String TITLE_STRING_WITH_THIS = "{0} this:{1} ()";
 
-    public static final String TOO_LONG_NAME = "this name pattern is too long, over 150 symbols! Guys, what are" +
+    private static final String TITLE_STRING_WITH_UNBOUND_RANGE = "{6+}, {0}, {2}";
+
+    private static final String TITLE_STRING_WITH_MULTIPLE_UNBOUND_RANGES = "{1+}, {0}, {2+}";
+
+    private static final String TITLE_STRING_WITH_WRONG_UNBOUND_RANGE = "{2+}, {0}, {3+}";
+
+    private static final String TITLE_STRING_WITH_MIXED_RANGES = "{0-2}, {2+}, {0}";
+
+    private static final String TOO_LONG_NAME = "this name pattern is too long, over 150 symbols! Guys, what are" +
             " you thinking for when you made so long title??? Could you please made it more carefully...?";
 
     @Test
@@ -209,5 +217,40 @@ public class AllureAspectUtilsTest {
         assertThat("Invalid method name short cut", name,
                 equalTo("getSomethingNew[this name pattern is too long, over 150 symbols! Guys, what are you " +
                         "thinking for when you made so long t...]"));
+    }
+
+    @Test
+    public void getTitleWithUnboundRangeValues() {
+        String[] firstArg = {"first string", "second string", "third string", "fourth string", "fifth string",
+                "sixth string", "seventh string", "eighth string", "ninth string"};
+        String title = getTitle(TITLE_STRING_WITH_UNBOUND_RANGE, METHOD_NAME, null, firstArg);
+        String[] expectedOutput = {"seventh string", "eighth string", "ninth string", "first string", "third string"};
+        assertThat("Unbound arguments' range is processed incorrectly", title,
+                equalTo(Arrays.toString(expectedOutput).replace("[", "").replace("]", "")));
+    }
+
+    @Test
+    public void getTitleWithMultipleUnboundRangeValues() {
+        String[] firstArg = {"first string", "second string", "third string", "fourth string"};
+        String title = getTitle(TITLE_STRING_WITH_MULTIPLE_UNBOUND_RANGES, METHOD_NAME, null, firstArg);
+        String[] expectedOutput = {"second string", "third string", "fourth string", "first string", "third string", "fourth string"};
+        assertThat("Unbound arguments' range is processed incorrectly", title,
+                equalTo(Arrays.toString(expectedOutput).replace("[", "").replace("]", "")));
+    }
+
+    @Test
+    public void getTitleWithWrongUnboundRangeValues() {
+        String firstArg = "first string";
+        String title = getTitle(TITLE_STRING_WITH_WRONG_UNBOUND_RANGE, METHOD_NAME, null, new Object[]{firstArg});
+        assertThat("Unbound arguments' range is processed incorrectly", title, equalTo(firstArg));
+    }
+
+    @Test
+    public void getTitleWithMixedRangeValues() {
+        String[] firstArg = new String[] {"first string", "second string", "third string", "fourth string"};
+        String title = getTitle(TITLE_STRING_WITH_MIXED_RANGES, METHOD_NAME, null, firstArg);
+        String[] expectedOutput = {"first string", "second string", "third string","third string", "fourth string", "first string"};
+        assertThat("Mixed arguments' range is processed incorrectly", title,
+                equalTo(Arrays.toString(expectedOutput).replace("[", "").replace("]", "")));
     }
 }


### PR DESCRIPTION
Proposal request: in case of a big amount of input parameters, it'd be great to be able to specify index ranges. In the following update there were added 2 new types of placeholders: 1) `{i-j}` range, where `i` = start index, `j` = end index; 2) `{i+}` range, where `i` = start index, `+` means looping till the end. You can find usage examples in newly added tests.

On a highest level, it'd look like the following:
```java
@Step("Verify that {0-1} email contains {2+} items")
public void verifyEmailBodyContains(EmailSubject subject, EmailType type, EmailBodyPart... parts)
```