### PR TITLE
Feature: uri-list support

### DIFF
--- a/allure-model/src/test/resources/allure-results/00a0bc5a-6372-4e66-8088-1571966a056b-attachment.uri
+++ b/allure-model/src/test/resources/allure-results/00a0bc5a-6372-4e66-8088-1571966a056b-attachment.uri
@@ -1,0 +1,5 @@
+#
+data/8e86c8ae-c2cd-49d4-a1b8-87592aa6de02-attachment.png
+
+data/aae99fa5-af39-461f-b218-b1e4f2a88e56-attachment.webm
+ #

--- a/allure-model/src/test/resources/allure-results/c32503a8-2981-43da-afa5-e0d82dacfefd-testsuite.xml
+++ b/allure-model/src/test/resources/allure-results/c32503a8-2981-43da-afa5-e0d82dacfefd-testsuite.xml
@@ -108,6 +108,7 @@ Expected: "{\n\"name\": \"test\",\n\"value\": \"ok value\"\n}"
                 <attachment title="JPG Attachment" source="8e86c8ae-c2cd-49d4-a1b8-87592aa6de02-attachment.png" type="image/png"/>
                 <attachment title="CSV Attachment" source="b81da3c0-1b9d-4219-9e35-87e139ec446c-attachment.csv" type="text/csv"/>
                 <attachment title="WEBM Attachment" source="aae99fa5-af39-461f-b218-b1e4f2a88e56-attachment.webm" type="video/webm"/>
+                <attachment title="URI Attachment" source="00a0bc5a-6372-4e66-8088-1571966a056b-attachment.uri" type="text/uri-list"/>
             </attachments>
             <labels>
                 <label name="severity" value="critical"/>

--- a/allure-report-data/src/test/java/ru/yandex/qatools/allure/data/AllureReportGeneratorTest.java
+++ b/allure-report-data/src/test/java/ru/yandex/qatools/allure/data/AllureReportGeneratorTest.java
@@ -42,7 +42,7 @@ public class AllureReportGeneratorTest {
         assertThat(dataDirectory, contains(PluginManager.WIDGETS_JSON));
         assertThat(dataDirectory, contains(ReportWriter.REPORT_JSON));
 
-        assertThat(dataDirectory, hasFilesCount(13, "*-attachment*"));
+        assertThat(dataDirectory, hasFilesCount(14, "*-attachment*"));
         assertThat(dataDirectory, hasFilesCount(319, "*-testcase.json"));
     }
 

--- a/allure-report-face/src/components/attachment/AttachmentView.hbs
+++ b/allure-report-face/src/components/attachment/AttachmentView.hbs
@@ -45,6 +45,16 @@
             Your browser does not support video tag
         </video>
     </div>
+{{else if (eq type "uri")}}
+    <table class="table attachment__table">
+        <tbody>
+        {{#each content}}
+            <tr>
+                <td><a href="{{.}}" target="_blank">{{.}}</a></td>
+            </tr>
+        {{/each}}
+        </tbody>
+    </table>
 {{else}}
     <iframe class="attachment__iframe" frameborder="0" src="{{sourceUrl}}"></iframe>
 {{/if}}

--- a/allure-report-face/src/components/attachment/AttachmentView.js
+++ b/allure-report-face/src/components/attachment/AttachmentView.js
@@ -1,6 +1,7 @@
 import './styles.css';
 import d3 from 'd3';
 import highlight from '../../util/highlight';
+import splitUriList from '../../helpers/splitUriList';
 import {ItemView} from 'backbone.marionette';
 import $ from 'jquery';
 import router from '../../router';
@@ -39,6 +40,8 @@ class AttachmentView extends ItemView {
         return $.ajax(this.sourceUrl, {dataType: 'text'}).then((responseText) => {
             if(this.type === 'csv') {
                 this.content = d3.csv.parseRows(responseText);
+            } else if(this.type === 'uri') {
+                this.content = splitUriList(responseText);
             } else {
                 this.content = responseText;
             }
@@ -46,7 +49,7 @@ class AttachmentView extends ItemView {
     }
 
     needsFetch() {
-        return ['text', 'code', 'csv'].indexOf(this.type) > -1;
+        return ['text', 'code', 'csv', 'uri'].indexOf(this.type) > -1;
     }
 
     serializeData() {

--- a/allure-report-face/src/helpers/splitUriList.js
+++ b/allure-report-face/src/helpers/splitUriList.js
@@ -1,0 +1,6 @@
+export default function splitUriList(uri) {
+    var os = require('os');
+    return uri.split(os.EOL).filter(function (el) {
+        return el.trim().length > 0 && !el.trim().startsWith('#');
+    });
+}

--- a/allure-report-face/src/util/attachmentType.js
+++ b/allure-report-face/src/util/attachmentType.js
@@ -30,6 +30,8 @@ export default function typeByMime(type) {
         case 'video/ogg':
         case 'video/webm':
             return 'video';
+        case 'text/uri-list':
+            return 'uri';
         default:
     }
 }


### PR DESCRIPTION
See initial request #412 

Motivation: to avoid loading heavy attachments into report's context, it'd be nice to be able to attach just a list of URIs for further manual downloading.

Adding URI as a return type will affect core and require some effort on refactoring. 

Current approach assumes pure report face involvement. Implementation itself is based on `text/uri-list` mime type.

As input user could use the following syntax:
```java
	@Attachment(value = "{0}", type = "text/uri-list")
	public String saveLinks(final String attachName, final List<String> uris) {
		return uris.stream().collect(joining(System.lineSeparator()));
	}
```
As output there will be provided a table-based list of links.
<a href="http://www.imagecross.com/"><img src="http://hostingd.imagecross.com/image-hosting-08/4827uri-list.png"></a><br><a href="http://www.imagecross.com/">Image Hosting</a>

Click will either trigger a new tab opening (if file is already on server) or direct file downloading.

Changelog:
 * added new `text/uri-list` attachment type;
 * added corresponding dummy data;
 * increased amount of expected inputs in one of `AllureReportGenerator` tests;
 * added helper method for splitting an input string into URIs list according to specification rules.