### PR TITLE
Test case details: minor visual improvement

### DIFF
--- a/allure-report-face/src/main/webapp/templates/testcase/testcase.html
+++ b/allure-report-face/src/main/webapp/templates/testcase/testcase.html
@@ -14,8 +14,10 @@
     </h3>
     <div class="external-system-references">
         <span ng-show="testcaseArguments.length > 0">
-            <span class="fa fa-sliders"/>
-            <span>{{'testcase.PARAMETERS' | translate}}: [</span>
+            <span class="fa fa-sliders">
+                {{'testcase.PARAMETERS' | translate}}:
+            </span>
+            <span>[</span>
             <span ng-repeat="argument in testcaseArguments">
                 <span class="line-nobreak">
                     <span>{{argument.name}} = "
@@ -28,15 +30,17 @@
             <span>]</span>
         </span>
         <span class="issues" ng-show="testcase.issues">
-            <span class="fa fa-bug"/>
-            {{'testcase.ISSUES' | translate}}
+            <span class="fa fa-bug">
+                {{'testcase.ISSUES' | translate}}
+            </span>
             <span class="issue" ng-repeat="issue in testcase.issues">
                 <a ng-href="{{issue.url}}" target="_blank">{{issue.name}}</a><span ng-show="!$last">,</span>
             </span>
         </span>
         <span class="testId" ng-show="testcase.testId">
-            <span class="fa fa-database"/>
-            {{'testcase.TEST_ID' | translate}}
+            <span class="fa fa-database">
+                {{'testcase.TEST_ID' | translate}}
+            </span>
             <a ng-href="{{testcase.testId.url}}" target="_blank">{{testcase.testId.name}}</a>
         </span>
     </div>


### PR DESCRIPTION
As you can see on the screenshot icon and label can't be broken by new line any more. As a side effect label font decreased slightly (which is good IMO, since it visually is not mixed with values any more).

![image](https://cloud.githubusercontent.com/assets/743546/14918271/d45304a0-0e1a-11e6-9545-dbb56411c677.png)
