### PR TITLE
Add more digits for timeline

### DIFF
--- a/allure-report-face/src/helpers/duration.js
+++ b/allure-report-face/src/helpers/duration.js
@@ -36,7 +36,7 @@ export default function(timeInt, count) {
         }))
         .reduce(({hasValue, out}, token) => {
             hasValue = hasValue || token.value > 0;
-            if(hasValue) {
+            if(token.value > 0 || (hasValue && token.suffix !== 'ms')) {
                 out.push(token);
             }
             return {hasValue, out};

--- a/allure-report-face/src/plugins/timeline/TimelineView.js
+++ b/allure-report-face/src/plugins/timeline/TimelineView.js
@@ -52,7 +52,7 @@ class TimelineView extends BaseChartView {
         });
 
         this.makeAxis(this.svg.select('.chart__axis_x'), {
-            tickFormat: d => duration(d, 1),
+            tickFormat: d => duration(d, 2),
             scale: this.x,
             orient: 'bottom'
         }, {

--- a/allure-report-face/test/helpers/duration.spec.js
+++ b/allure-report-face/test/helpers/duration.spec.js
@@ -14,19 +14,25 @@ describe('duration helper', function() {
 
     it('should humanize durations', function() {
         expect(duration(10)).toBe('10ms');
-        expect(duration(MINUTE)).toBe('1m 00s 000ms');
+        expect(duration(MINUTE)).toBe('1m 00s');
         expect(duration(66 * SECOND + 1)).toBe('1m 06s 001ms');
-        expect(duration(35 * MINUTE)).toBe('35m 00s 000ms');
+        expect(duration(35 * MINUTE)).toBe('35m 00s');
         expect(duration(HOUR)).toBe('1h 00m 00s');
         expect(duration(5 * HOUR + 10 * MINUTE + 5 * SECOND)).toBe('5h 10m 05s');
         expect(duration(DAY)).toBe('1d 00h 00m');
         expect(duration(DAY + 5 * MINUTE)).toBe('1d 00h 05m');
     });
 
+    it('should render only non-zero milliseconds', function() {
+        expect(duration(100)).toBe('100ms');
+        expect(duration(1000)).toBe('1s');
+        expect(duration(1100)).toBe('1s 100ms');
+    });
+
     it('should can limit count of signs', function() {
         expect(duration(10, 1)).toBe('10ms');
         expect(duration(MINUTE, 1)).toBe('1m');
         expect(duration(HOUR, 2)).toBe('1h 00m');
-        expect(duration(HOUR, 4)).toBe('1h 00m 00s 000ms');
+        expect(duration(DAY + HOUR + 10, 4)).toBe('1d 01h 00m 00s');
     });
 });


### PR DESCRIPTION
It haven't done before because that looked not good on our example 

<img width="500" alt="screen shot 2016-06-05 at 21 53 21" src="https://cloud.githubusercontent.com/assets/812240/15807923/d8b15eb8-2b69-11e6-9e62-125fe49888df.png">

Now I added workaround for it.
Fixes #815