### PR TITLE
New labels as a part of testng-adaptor improvements

### DIFF
--- a/allure-model/src/main/java/ru/yandex/qatools/allure/config/AllureModelUtils.java
+++ b/allure-model/src/main/java/ru/yandex/qatools/allure/config/AllureModelUtils.java
@@ -67,6 +67,22 @@ public final class AllureModelUtils {
         return createLabel(LabelName.THREAD, thread);
     }
 
+    public static Label createTestSuiteLabel(String testSuite) {
+        return createLabel(LabelName.TEST_SUITE, testSuite);
+    }
+
+    public static Label createTestGroupLabel(String testGroup) {
+        return createLabel(LabelName.TEST_GROUP, testGroup);
+    }
+
+    public static Label createTestClassLabel(String testClass) {
+        return createLabel(LabelName.TEST_CLASS, testClass);
+    }
+
+    public static Label createTestMethodLabel(String testMethod) {
+        return createLabel(LabelName.TEST_METHOD, testMethod);
+    }
+
     public static Label createLabel(LabelName name, String value) {
         return new Label().withName(name.value()).withValue(value);
     }

--- a/allure-model/src/main/resources/allure.xsd
+++ b/allure-model/src/main/resources/allure.xsd
@@ -162,6 +162,10 @@
             <xs:enumeration value="testId"/>
             <xs:enumeration value="host"/>
             <xs:enumeration value="thread"/>
+            <xs:enumeration value="testSuite"/>
+            <xs:enumeration value="testGroup"/>
+            <xs:enumeration value="testClass"/>
+            <xs:enumeration value="testMethod"/>
         </xs:restriction>
     </xs:simpleType>
 

--- a/allure-testng-adaptor/src/main/java/ru/yandex/qatools/allure/testng/AllureTestListener.java
+++ b/allure-testng-adaptor/src/main/java/ru/yandex/qatools/allure/testng/AllureTestListener.java
@@ -124,6 +124,10 @@ public class AllureTestListener implements IResultListener, ISuiteListener {
     @Override
     public void onTestStart(ITestResult iTestResult) {
         ITestNGMethod method = iTestResult.getMethod();
+	    String testSuiteLabel = iTestResult.getTestContext().getSuite().getName();
+	    String testGroupLabel = iTestResult.getTestContext().getCurrentXmlTest().getName();
+	    String testClassLabel = iTestResult.getTestClass().getName();
+	    String testMethodLabel = method.getMethodName();
         String suitePrefix = getCurrentSuitePrefix(iTestResult);
         String testName = getName(iTestResult);
         startedTestNames.add(testName);
@@ -132,7 +136,11 @@ public class AllureTestListener implements IResultListener, ISuiteListener {
         String invoc = getMethodInvocationsAndSuccessPercentage(iTestResult);
         Description description = new Description().withValue(method.getDescription());
         String suiteUid = getSuiteUid(iTestResult.getTestContext());
-        TestCaseStartedEvent event = new TestCaseStartedEvent(suiteUid, testName + invoc);
+        TestCaseStartedEvent event = new TestCaseStartedEvent(suiteUid, testName + invoc).withLabels(
+		        AllureModelUtils.createTestSuiteLabel(testSuiteLabel),
+		        AllureModelUtils.createTestGroupLabel(testGroupLabel),
+		        AllureModelUtils.createTestClassLabel(testClassLabel),
+		        AllureModelUtils.createTestMethodLabel(testMethodLabel));
         if (description.getValue() != null) {
             event.setDescription(description);
         }

--- a/allure-testng-adaptor/src/main/java/ru/yandex/qatools/allure/testng/AllureTestListener.java
+++ b/allure-testng-adaptor/src/main/java/ru/yandex/qatools/allure/testng/AllureTestListener.java
@@ -124,10 +124,10 @@ public class AllureTestListener implements IResultListener, ISuiteListener {
     @Override
     public void onTestStart(ITestResult iTestResult) {
         ITestNGMethod method = iTestResult.getMethod();
-	    String testSuiteLabel = iTestResult.getTestContext().getSuite().getName();
-	    String testGroupLabel = iTestResult.getTestContext().getCurrentXmlTest().getName();
-	    String testClassLabel = iTestResult.getTestClass().getName();
-	    String testMethodLabel = method.getMethodName();
+        String testSuiteLabel = iTestResult.getTestContext().getSuite().getName();
+        String testGroupLabel = iTestResult.getTestContext().getCurrentXmlTest().getName();
+        String testClassLabel = iTestResult.getTestClass().getName();
+        String testMethodLabel = method.getMethodName();
         String suitePrefix = getCurrentSuitePrefix(iTestResult);
         String testName = getName(iTestResult);
         startedTestNames.add(testName);
@@ -137,10 +137,10 @@ public class AllureTestListener implements IResultListener, ISuiteListener {
         Description description = new Description().withValue(method.getDescription());
         String suiteUid = getSuiteUid(iTestResult.getTestContext());
         TestCaseStartedEvent event = new TestCaseStartedEvent(suiteUid, testName + invoc).withLabels(
-		        AllureModelUtils.createTestSuiteLabel(testSuiteLabel),
-		        AllureModelUtils.createTestGroupLabel(testGroupLabel),
-		        AllureModelUtils.createTestClassLabel(testClassLabel),
-		        AllureModelUtils.createTestMethodLabel(testMethodLabel));
+                AllureModelUtils.createTestSuiteLabel(testSuiteLabel),
+                AllureModelUtils.createTestGroupLabel(testGroupLabel),
+                AllureModelUtils.createTestClassLabel(testClassLabel),
+                AllureModelUtils.createTestMethodLabel(testMethodLabel));
         if (description.getValue() != null) {
             event.setDescription(description);
         }
@@ -163,7 +163,7 @@ public class AllureTestListener implements IResultListener, ISuiteListener {
     @Override
     public void onTestFailure(ITestResult iTestResult) {
         getLifecycle().fire(new TestCaseFailureEvent()
-                        .withThrowable(iTestResult.getThrowable())
+                .withThrowable(iTestResult.getThrowable())
         );
         fireFinishTest();
     }

--- a/allure-testng-adaptor/src/test/java/ru/yandex/qatools/allure/testng/AllureTestListenerTest.java
+++ b/allure-testng-adaptor/src/test/java/ru/yandex/qatools/allure/testng/AllureTestListenerTest.java
@@ -6,7 +6,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 import org.testng.*;
 import org.testng.internal.ConstructorOrMethod;
-import org.testng.xml.XmlClass;
 import org.testng.xml.XmlTest;
 
 import ru.yandex.qatools.allure.Allure;
@@ -41,8 +40,8 @@ public class AllureTestListenerTest {
     private static final String DEFAULT_TEST_NAME = "test";
     private static final String DEFAULT_SUITE_NAME = "suite";
     private static final String DEFAULT_XML_TEST_NAME = "testxml";
-	private static final String DEFAULT_CLASS_NAME = "class";
-    
+    private static final String DEFAULT_CLASS_NAME = "class";
+
     private AllureTestListener testngListener;
     private Allure allure;
     private ITestContext testContext;
@@ -55,14 +54,14 @@ public class AllureTestListenerTest {
         allure = mock(Allure.class);
 
         testngListener.setLifecycle(allure);
-        
+
         ISuite suite = mock(ISuite.class);
-    	when(suite.getName()).thenReturn(DEFAULT_SUITE_NAME);
-    	XmlTest xmlTest = mock(XmlTest.class);
-    	when(xmlTest.getName()).thenReturn(DEFAULT_XML_TEST_NAME);
-    	testContext = mock(ITestContext.class);
-    	when(testContext.getSuite()).thenReturn(suite);
-    	when(testContext.getCurrentXmlTest()).thenReturn(xmlTest);
+        when(suite.getName()).thenReturn(DEFAULT_SUITE_NAME);
+        XmlTest xmlTest = mock(XmlTest.class);
+        when(xmlTest.getName()).thenReturn(DEFAULT_XML_TEST_NAME);
+        testContext = mock(ITestContext.class);
+        when(testContext.getSuite()).thenReturn(suite);
+        when(testContext.getCurrentXmlTest()).thenReturn(xmlTest);
 
         // mocking test method parameters
         ConstructorOrMethod constructorOrMethod = mock(ConstructorOrMethod.class);
@@ -72,30 +71,30 @@ public class AllureTestListenerTest {
         testResult = mock(ITestResult.class);
         when(testResult.getMethod()).thenReturn(method);
         when(testResult.getParameters()).thenReturn(new Object[]{});
-	    IClass iClass = mock(IClass.class);
-	    when(testResult.getTestClass()).thenReturn(iClass);
+        IClass iClass = mock(IClass.class);
+        when(testResult.getTestClass()).thenReturn(iClass);
     }
 
     @Test
     public void skipTestFireTestCaseStartedEvent() {
-	    when(testResult.getTestContext()).thenReturn(testContext);
+        when(testResult.getTestContext()).thenReturn(testContext);
         when(testResult.getName()).thenReturn(DEFAULT_TEST_NAME);
-	    when(testResult.getTestContext().getSuite().getName()).thenReturn(DEFAULT_SUITE_NAME);
-	    when(testResult.getTestContext().getCurrentXmlTest().getName()).thenReturn(DEFAULT_XML_TEST_NAME);
-	    when(testResult.getTestClass().getName()).thenReturn(DEFAULT_CLASS_NAME);
-	    when(testResult.getMethod().getMethodName()).thenReturn(DEFAULT_TEST_NAME);
+        when(testResult.getTestContext().getSuite().getName()).thenReturn(DEFAULT_SUITE_NAME);
+        when(testResult.getTestContext().getCurrentXmlTest().getName()).thenReturn(DEFAULT_XML_TEST_NAME);
+        when(testResult.getTestClass().getName()).thenReturn(DEFAULT_CLASS_NAME);
+        when(testResult.getMethod().getMethodName()).thenReturn(DEFAULT_TEST_NAME);
         doReturn(new Annotation[0]).when(testngListener).getMethodAnnotations(testResult);
-        
+
         String uid = UUID.randomUUID().toString();
         when(testContext.getAttribute("SUITE_UID")).thenReturn(uid);
         testngListener.onTestSkipped(testResult);
 
         String suiteUid = testngListener.getSuiteUid(testContext);
-	    verify(allure).fire(eq(withExecutorInfo(new TestCaseStartedEvent(suiteUid, DEFAULT_TEST_NAME).withLabels(
-			    AllureModelUtils.createTestSuiteLabel(DEFAULT_SUITE_NAME),
-			    AllureModelUtils.createTestGroupLabel(DEFAULT_XML_TEST_NAME),
-			    AllureModelUtils.createTestClassLabel(DEFAULT_CLASS_NAME),
-			    AllureModelUtils.createTestMethodLabel(DEFAULT_TEST_NAME)))));
+        verify(allure).fire(eq(withExecutorInfo(new TestCaseStartedEvent(suiteUid, DEFAULT_TEST_NAME).withLabels(
+                AllureModelUtils.createTestSuiteLabel(DEFAULT_SUITE_NAME),
+                AllureModelUtils.createTestGroupLabel(DEFAULT_XML_TEST_NAME),
+                AllureModelUtils.createTestClassLabel(DEFAULT_CLASS_NAME),
+                AllureModelUtils.createTestMethodLabel(DEFAULT_TEST_NAME)))));
     }
 
     @Test
@@ -133,14 +132,14 @@ public class AllureTestListenerTest {
         String anotherStringParameter = "anotherString";
         when(testResult.getTestContext()).thenReturn(testContext);
         when(testResult.getName()).thenReturn(DEFAULT_TEST_NAME);
-	    when(testResult.getTestContext().getSuite().getName()).thenReturn(DEFAULT_SUITE_NAME);
-	    when(testResult.getTestContext().getCurrentXmlTest().getName()).thenReturn(DEFAULT_XML_TEST_NAME);
-	    when(testResult.getTestClass().getName()).thenReturn(DEFAULT_CLASS_NAME);
-	    when(testResult.getMethod().getMethodName()).thenReturn(DEFAULT_TEST_NAME);
-        when(testResult.getParameters()).thenReturn(new Object[] { doubleParameter, stringParameter, anotherStringParameter});
+        when(testResult.getTestContext().getSuite().getName()).thenReturn(DEFAULT_SUITE_NAME);
+        when(testResult.getTestContext().getCurrentXmlTest().getName()).thenReturn(DEFAULT_XML_TEST_NAME);
+        when(testResult.getTestClass().getName()).thenReturn(DEFAULT_CLASS_NAME);
+        when(testResult.getMethod().getMethodName()).thenReturn(DEFAULT_TEST_NAME);
+        when(testResult.getParameters()).thenReturn(new Object[]{doubleParameter, stringParameter, anotherStringParameter});
 
         doReturn(new Annotation[0]).when(testngListener).getMethodAnnotations(testResult);
-        
+
         String uid = UUID.randomUUID().toString();
         when(testContext.getAttribute("SUITE_UID")).thenReturn(uid);
         testngListener.onTestStart(testResult);
@@ -149,10 +148,10 @@ public class AllureTestListenerTest {
         String testName = String.format("%s[%s,%s,%s]",
                 DEFAULT_TEST_NAME, Double.toString(doubleParameter), stringParameter, anotherStringParameter);
         verify(allure).fire(eq(withExecutorInfo(new TestCaseStartedEvent(suiteUid, testName).withLabels(
-		        AllureModelUtils.createTestSuiteLabel(DEFAULT_SUITE_NAME),
-		        AllureModelUtils.createTestGroupLabel(DEFAULT_XML_TEST_NAME),
-		        AllureModelUtils.createTestClassLabel(DEFAULT_CLASS_NAME),
-		        AllureModelUtils.createTestMethodLabel(DEFAULT_TEST_NAME)))));
+                AllureModelUtils.createTestSuiteLabel(DEFAULT_SUITE_NAME),
+                AllureModelUtils.createTestGroupLabel(DEFAULT_XML_TEST_NAME),
+                AllureModelUtils.createTestClassLabel(DEFAULT_CLASS_NAME),
+                AllureModelUtils.createTestMethodLabel(DEFAULT_TEST_NAME)))));
 
         ArgumentCaptor<AddParameterEvent> captor = ArgumentCaptor.forClass(AddParameterEvent.class);
         verify(allure, times(2)).fire(captor.capture());


### PR DESCRIPTION
  - according to #558 and #610 requests, there were added additional labels for further adaptor improvements and plugins development;
  - testng-adaptor will now supply 4 additional labels into TestCases for easier filtering by suites / groups / classes / test names.