### PR TITLE
pie chart: percentage precision is 2 to postpone "100% passed" issue

### DIFF
--- a/allure-report-face/src/main/webapp/js/charts/pie.js
+++ b/allure-report-face/src/main/webapp/js/charts/pie.js
@@ -129,7 +129,7 @@ angular.module('allure.core.charts.pie', ['allure.core.charts.util']).directive(
         },
         link: function ($scope, elm) {
             $scope.$watch('data', function (data) {
-                var format = $scope.tooltipTpl || '<div><b>{{ \'graph.TESTS\' | translate:"{ amount: value }":"messageformat" }} ({{data.part * 100 | number:0}}%)</b></div>' +
+                var format = $scope.tooltipTpl || '<div><b>{{ \'graph.TESTS\' | translate:"{ amount: value }":"messageformat" }} ({{data.part * 100 | number:2}}%)</b></div>' +
                     '<div>{{data.name | translate}}</div>';
                 $scope.chart = new PieChart(elm[0], $scope, data);
                 $scope.chart.setTooltipFormat(format);


### PR DESCRIPTION
This is already fixed in master. But (since we have to support our Allure plugins for transition period) we would like to have it in 1.4.x branch as well.

Before:
![100_passed](https://cloud.githubusercontent.com/assets/743546/16565693/ac57144c-4217-11e6-9fce-149503afad01.png)

After:
![1_failed](https://cloud.githubusercontent.com/assets/743546/16565702/b64a5cd4-4217-11e6-8d2b-2d5ae66c485f.png)
