### PR TITLE
Feature - story links

### DIFF
--- a/allure-java-adaptor-api/src/main/java/ru/yandex/qatools/allure/utils/AnnotationManager.java
+++ b/allure-java-adaptor-api/src/main/java/ru/yandex/qatools/allure/utils/AnnotationManager.java
@@ -153,16 +153,6 @@ public class AnnotationManager {
             event.getLabels().add(createTestLabel(getTestCaseId()));
         }
 
-        if (isStoryAnnotationPresent()) {
-            event.getLabels().add(createStoryLabel(getStoryKey()));
-        }
-
-        if (isStoriesAnnotationPresent()) {
-            for (String storyKey : getStoryKeys()) {
-                event.getLabels().add(createStoryLabel(storyKey));
-            }
-        }
-
         event.getLabels().addAll(getStoryLabels());
         event.getLabels().addAll(getFeatureLabels());
         withExecutorInfo(event);
@@ -310,13 +300,14 @@ public class AnnotationManager {
      * @return {@link java.util.List} of created labels
      */
     public List<Label> getStoryLabels() {
-        if (!isAnnotationPresent(Stories.class)) {
-            return Collections.emptyList();
-        }
-
         List<Label> result = new ArrayList<>();
-        for (Story story : getAnnotation(Stories.class).value()) {
-            result.add(createStoryLabel(story.value()));
+        if (isStoryAnnotationPresent()) {
+            result.add(createStoryLabel(getStoryKey()));
+        }
+        if (isStoriesAnnotationPresent()) {
+            for (String storyKey : getStoryKeys()) {
+                result.add(createStoryLabel(storyKey));
+            }
         }
         return result;
     }

--- a/allure-java-adaptor-api/src/main/java/ru/yandex/qatools/allure/utils/AnnotationManager.java
+++ b/allure-java-adaptor-api/src/main/java/ru/yandex/qatools/allure/utils/AnnotationManager.java
@@ -2,14 +2,7 @@ package ru.yandex.qatools.allure.utils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import ru.yandex.qatools.allure.annotations.Description;
-import ru.yandex.qatools.allure.annotations.Features;
-import ru.yandex.qatools.allure.annotations.Issue;
-import ru.yandex.qatools.allure.annotations.Issues;
-import ru.yandex.qatools.allure.annotations.Severity;
-import ru.yandex.qatools.allure.annotations.Stories;
-import ru.yandex.qatools.allure.annotations.TestCaseId;
-import ru.yandex.qatools.allure.annotations.Title;
+import ru.yandex.qatools.allure.annotations.*;
 import ru.yandex.qatools.allure.events.TestCaseStartedEvent;
 import ru.yandex.qatools.allure.events.TestSuiteStartedEvent;
 import ru.yandex.qatools.allure.model.Label;
@@ -160,6 +153,16 @@ public class AnnotationManager {
             event.getLabels().add(createTestLabel(getTestCaseId()));
         }
 
+        if (isStoryAnnotationPresent()) {
+            event.getLabels().add(createStoryLabel(getStoryKey()));
+        }
+
+        if (isStoriesAnnotationPresent()) {
+            for (String storyKey : getStoryKeys()) {
+                event.getLabels().add(createStoryLabel(storyKey));
+            }
+        }
+
         event.getLabels().addAll(getStoryLabels());
         event.getLabels().addAll(getFeatureLabels());
         withExecutorInfo(event);
@@ -248,6 +251,9 @@ public class AnnotationManager {
         return isAnnotationPresent(TestCaseId.class);
     }
 
+    public boolean isStoryAnnotationPresent() {
+        return isAnnotationPresent(Story.class);
+    }
     /**
      * Find first {@link ru.yandex.qatools.allure.annotations.Title} annotation
      *
@@ -309,10 +315,27 @@ public class AnnotationManager {
         }
 
         List<Label> result = new ArrayList<>();
-        for (String story : getAnnotation(Stories.class).value()) {
-            result.add(createStoryLabel(story));
+        for (Story story : getAnnotation(Stories.class).value()) {
+            result.add(createStoryLabel(story.value()));
         }
         return result;
+    }
+
+    public String getStoryKey() {
+        Story story = getAnnotation(Story.class);
+        return story == null ? null : story.value();
+    }
+
+    public String[] getStoryKeys() {
+        Stories stories = getAnnotation(Stories.class);
+        if (stories == null) {
+            return new String[0];
+        }
+        List<String> keys = new ArrayList<>();
+        for (Story story : stories.value()) {
+            keys.add(story.value());
+        }
+        return keys.toArray(new String[keys.size()]);
     }
 
     /**

--- a/allure-java-adaptor-api/src/test/java/ru/yandex/qatools/allure/utils/AnnotationManagerTest.java
+++ b/allure-java-adaptor-api/src/test/java/ru/yandex/qatools/allure/utils/AnnotationManagerTest.java
@@ -76,8 +76,8 @@ public class AnnotationManagerTest {
     @Test
     public void testStoryLabelsGetter() throws Exception {
         List<Label> labels = annotationManager.getStoryLabels();
-        assertThat(labels, hasSize(2));
-        assertEquals(labels.get(0), createLabel(LabelName.STORY, "some.nested.story.1"));
+        assertThat(labels, hasSize(3));
+        assertEquals(labels.get(0), createLabel(LabelName.STORY, "some.simple.story"));
     }
 
     @Test

--- a/allure-java-adaptor-api/src/test/java/ru/yandex/qatools/allure/utils/AnnotationManagerTest.java
+++ b/allure-java-adaptor-api/src/test/java/ru/yandex/qatools/allure/utils/AnnotationManagerTest.java
@@ -76,8 +76,8 @@ public class AnnotationManagerTest {
     @Test
     public void testStoryLabelsGetter() throws Exception {
         List<Label> labels = annotationManager.getStoryLabels();
-        assertThat(labels, hasSize(1));
-        assertEquals(labels.get(0), createLabel(LabelName.STORY, "some.story"));
+        assertThat(labels, hasSize(2));
+        assertEquals(labels.get(0), createLabel(LabelName.STORY, "some.nested.story.1"));
     }
 
     @Test
@@ -102,8 +102,9 @@ public class AnnotationManagerTest {
                 createSeverityLabel(SeverityLevel.BLOCKER)
         )));
         assertThat(event.getLabels(), hasItems(
-                createStoryLabel("some.story"), 
                 createFeatureLabel("some.feature"),
+                createStoryLabel("some.nested.story.1"),
+                createStoryLabel("some.nested.story.2"),
                 createIssueLabel("some.simple.issue"),
                 createIssueLabel("some.nested.issue.1"),
                 createIssueLabel("some.nested.issue.2")
@@ -122,9 +123,10 @@ public class AnnotationManagerTest {
         assertThat(description.getType(), is(DescriptionType.TEXT));
 
         assertThat(event.getLabels(), hasItems(
-                createStoryLabel("some.story"), 
                 createFeatureLabel("some.feature"),
                 createSeverityLabel(SeverityLevel.BLOCKER),
+                createStoryLabel("some.nested.story.1"),
+                createStoryLabel("some.nested.story.2"),
                 createIssueLabel("some.simple.issue"),
                 createIssueLabel("some.nested.issue.1"),
                 createIssueLabel("some.nested.issue.2")
@@ -145,9 +147,11 @@ public class AnnotationManagerTest {
         assertThat(description.getType(), is(DescriptionType.TEXT));
 
         assertThat(event.getLabels(), hasItems(
-                createStoryLabel("some.story"), 
                 createFeatureLabel("some.feature"),
                 createSeverityLabel(SeverityLevel.BLOCKER),
+                createStoryLabel("some.simple.story"),
+                createStoryLabel("some.nested.story.1"),
+                createStoryLabel("some.nested.story.2"),
                 createIssueLabel("some.simple.issue"),
                 createIssueLabel("some.nested.issue.1"),
                 createIssueLabel("some.nested.issue.2"),

--- a/allure-java-adaptor-api/src/test/java/ru/yandex/qatools/allure/utils/testdata/SimpleClass.java
+++ b/allure-java-adaptor-api/src/test/java/ru/yandex/qatools/allure/utils/testdata/SimpleClass.java
@@ -11,7 +11,7 @@ import ru.yandex.qatools.allure.model.SeverityLevel;
 @Title("default.title")
 @Description("default.description")
 @Features("default.feature")
-@Stories("default.story")
+@Story("default.story")
 @Issue("default.issue")
 public class SimpleClass {
 
@@ -19,7 +19,11 @@ public class SimpleClass {
     @Description("some.description")
     @Severity(SeverityLevel.BLOCKER)
     @Features("some.feature")
-    @Stories("some.story")
+	@Story("some.simple.story")
+    @Stories({
+        @Story("some.nested.story.1"),
+        @Story("some.nested.story.2"),
+    })
     @Issue("some.simple.issue")
     @Issues({
         @Issue("some.nested.issue.1"),
@@ -28,14 +32,12 @@ public class SimpleClass {
     @TestCaseId("test.case.id")
     public void simpleMethod() {
     }
-    
-    public void defaultMethod(){	
+
+    public void defaultMethod(){
     }
-    
+
     @Severity(SeverityLevel.CRITICAL)
     @Issue("initial.issue")
     public void combinedMethod(){
     }
-    
-    
 }

--- a/allure-java-annotations/src/main/java/ru/yandex/qatools/allure/annotations/Stories.java
+++ b/allure-java-annotations/src/main/java/ru/yandex/qatools/allure/annotations/Stories.java
@@ -9,29 +9,33 @@ import java.lang.annotation.Target;
 /**
  * In order to group your tests by stories simply annotate test suite
  * or test case with {@link ru.yandex.qatools.allure.annotations.Stories}
- * annotation. This annotation can take either one string or a string
+ * annotation. This annotation can take {@link ru.yandex.qatools.allure.annotations.Story}
  * array because one test case can relate to several stories:
  * <pre>
- * &#064;Stories({"Story1", "Story2"})
+ * &#064;Stories({
+ *     &#064;Story("MYPROJECT-1"),
+ *     &#064;Story("MYPROJECT-2")
+ * })
  * &#064;Test
  * public void myTest() {
  *     ...
  * }
  *
- * &#064;Stories("Story")
+ * &#064;Story("Story")
  * &#064;Test
  * public void myTest() {
  *     ...
  * }
  * </pre>
  * @author Dmitry Baev charlie@yandex-team.ru
- *         Date: 25.12.13
+ * @author Sergey Korol serhii.s.korol@gmail.com
+ *         Date: 10.07.16
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.TYPE})
 public @interface Stories {
 
-    String[] value();
+    Story[] value();
 
 }

--- a/allure-java-annotations/src/main/java/ru/yandex/qatools/allure/annotations/Story.java
+++ b/allure-java-annotations/src/main/java/ru/yandex/qatools/allure/annotations/Story.java
@@ -1,0 +1,23 @@
+package ru.yandex.qatools.allure.annotations;
+
+import java.lang.annotation.*;
+
+/**
+ * Use this annotation to link a single story from issue tracker to test cases and test suites. Usage:
+ * <pre>
+ * &#064;Story("MYPROJECT-1")
+ * public void myTest() {
+ *     ...
+ * }
+ * </pre>
+ * @author Sergey Korol serhii.s.korol@gmail.com
+ *         Date: 10.07.16
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+public @interface Story {
+
+	String value();
+
+}

--- a/allure-java-annotations/src/main/java/ru/yandex/qatools/allure/annotations/Story.java
+++ b/allure-java-annotations/src/main/java/ru/yandex/qatools/allure/annotations/Story.java
@@ -10,6 +10,7 @@ import java.lang.annotation.*;
  *     ...
  * }
  * </pre>
+ *
  * @author Sergey Korol serhii.s.korol@gmail.com
  *         Date: 10.07.16
  */
@@ -18,6 +19,6 @@ import java.lang.annotation.*;
 @Target({ElementType.METHOD, ElementType.TYPE})
 public @interface Story {
 
-	String value();
+    String value();
 
 }

--- a/allure-model/src/test/resources/allure-results/0efd24bc-2ef8-4a28-9cb5-3a0c355933cd-testsuite.xml
+++ b/allure-model/src/test/resources/allure-results/0efd24bc-2ef8-4a28-9cb5-3a0c355933cd-testsuite.xml
@@ -12,6 +12,8 @@
                 <label name="issue" value="JIRA-1"/>
                 <label name="issue" value="JIRA-2"/>
                 <label name="testId" value="TMS-1"/>
+                <label name="story" value="JIRA-3"/>
+                <label name="story" value="JIRA-4"/>
             </labels>
         </test-case>
         <test-case start="1412949539363" stop="1412949539715" status="passed">

--- a/allure-report-data/src/main/groovy/ru/yandex/qatools/allure/data/converters/DefaultTestCaseConverter.groovy
+++ b/allure-report-data/src/main/groovy/ru/yandex/qatools/allure/data/converters/DefaultTestCaseConverter.groovy
@@ -70,6 +70,7 @@ class DefaultTestCaseConverter implements TestCaseConverter {
                 result.severity = source.severity;
                 result.testId = source.testId
                 result.issues = source.issues;
+                result.stories = source.stories;
 
                 def suiteName = source.suiteName ?: UNKNOWN_TEST_SUITE;
                 def suiteTitle = source.suiteTitle ?: TextUtils.humanize(suiteName);

--- a/allure-report-data/src/main/groovy/ru/yandex/qatools/allure/data/utils/PluginUtils.groovy
+++ b/allure-report-data/src/main/groovy/ru/yandex/qatools/allure/data/utils/PluginUtils.groovy
@@ -4,6 +4,7 @@ import org.codehaus.groovy.runtime.InvokerHelper
 import ru.yandex.qatools.allure.data.AllureTestCase
 import ru.yandex.qatools.allure.data.AllureTestCaseInfo
 import ru.yandex.qatools.allure.data.Issue
+import ru.yandex.qatools.allure.data.Story
 import ru.yandex.qatools.allure.data.Statistic
 import ru.yandex.qatools.allure.data.TestId
 import ru.yandex.qatools.allure.data.Time
@@ -71,6 +72,11 @@ final class PluginUtils {
     static def getIssues(TestCaseResult testCase) {
         def values = getLabelValues(testCase, ISSUE);
         values?.collect { new Issue(name: it, url: TextUtils.getIssueUrl(it)) }
+    }
+
+    static def getStories(TestCaseResult testCase) {
+        def values = getLabelValues(testCase, STORY);
+        values?.collect { new Story(name: it, url: TextUtils.getIssueUrl(it)) }
     }
 
     static def getSeverity(TestCaseResult testCase) {

--- a/allure-report-data/src/test/groovy/ru/yandex/qatools/allure/data/converters/DefaultTestCaseConverterTest.groovy
+++ b/allure-report-data/src/test/groovy/ru/yandex/qatools/allure/data/converters/DefaultTestCaseConverterTest.groovy
@@ -62,6 +62,7 @@ class DefaultTestCaseConverterTest {
 
         assert modify.attachments.empty
         assert modify.issues.empty
+        assert modify.stories.empty
         assert modify.labels.empty
         assert modify.parameters.empty
         assert modify.steps.empty

--- a/allure-report-face/src/plugins/testcase-links/LinksView.hbs
+++ b/allure-report-face/src/plugins/testcase-links/LinksView.hbs
@@ -10,5 +10,9 @@
             <span class="fa fa-bug"></span>
             <a class="link" href="{{this.url}}" target="_blank">{{name}}</a></span>
     {{/each}}
-
+    {{#each stories}}
+        <span class="testcase-link">
+            <span class="fa fa-tasks"></span>
+            <a class="link" href="{{this.url}}" target="_blank">{{name}}</a></span>
+    {{/each}}
 {{/if}}

--- a/allure-report-face/src/plugins/testcase-links/LinksView.js
+++ b/allure-report-face/src/plugins/testcase-links/LinksView.js
@@ -8,10 +8,10 @@ class IssuesView extends ItemView {
     template = template;
 
     serializeData() {
-        const {testId, issues} = this.model.attributes;
+        const {testId, issues, stories} = this.model.attributes;
         return {
-            hasLinks: testId || issues.length > 0,
-            testId, issues
+            hasLinks: testId || issues.length > 0 || stories.length > 0,
+            testId, issues, stories
         };
     }
 }

--- a/allure-report-plugin-api/src/main/resources/xsd/testcases.xsd
+++ b/allure-report-plugin-api/src/main/resources/xsd/testcases.xsd
@@ -33,6 +33,7 @@
             <xsd:element name="severity" type="alr:severity-level"/>
             <xsd:element name="status" type="alr:status"/>
             <xsd:element name="issues" type="alr:issues"/>
+            <xsd:element name="stories" type="alr:stories"/>
             <xsd:element name="testId" type="alr:testId" minOccurs="0"/>
             <xsd:element name="labels" type="alr:labels" minOccurs="0"/>
             <xsd:element name="parameters" type="alr:parameters" minOccurs="0"/>
@@ -129,6 +130,17 @@
     </xsd:complexType>
 
     <xsd:complexType name="issue">
+        <xsd:attribute name="name" type="xsd:string"/>
+        <xsd:attribute name="url" type="xsd:string"/>
+    </xsd:complexType>
+
+    <xsd:complexType name="stories">
+        <xsd:sequence>
+            <xsd:element name="story" type="alr:story" minOccurs="0" maxOccurs="unbounded"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="story">
         <xsd:attribute name="name" type="xsd:string"/>
         <xsd:attribute name="url" type="xsd:string"/>
     </xsd:complexType>


### PR DESCRIPTION
Partial implementation of initial #702 request:
 - updated Stories format to handle Story arrays;
 - updated testcases model with new story entities;
 - added corresponding story handlers into AnnotationManager;
 - fixed broken tests;
 - added stories links support into report face.

Here's how it looks like in report:

![image](https://cloud.githubusercontent.com/assets/6638780/16715582/af83779e-46ec-11e6-800b-ac0e6e275317.png)
