### PR TITLE
Methods that are excluded by a "groups" filter must not be included in the report

### DIFF
--- a/allure-testng-adaptor/src/main/java/ru/yandex/qatools/allure/testng/AllureTestListener.java
+++ b/allure-testng-adaptor/src/main/java/ru/yandex/qatools/allure/testng/AllureTestListener.java
@@ -1,5 +1,7 @@
 package ru.yandex.qatools.allure.testng;
 
+import static java.util.Arrays.asList;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.ISuite;
@@ -258,7 +260,7 @@ public class AllureTestListener implements IResultListener, ISuiteListener {
 
     private void addPendingMethods(ITestContext iTestContext) {
         for (ITestNGMethod method : iTestContext.getExcludedMethods()) {
-            if (method.isTest() && !method.getEnabled()) {
+            if (method.isTest() && !method.getEnabled() && isInActiveGroup(method, iTestContext)) {
                 Description description = new Description().withValue(method.getDescription());
                 String suiteUid = getSuiteUid(iTestContext);
                 TestCaseStartedEvent event = new TestCaseStartedEvent(suiteUid, method.getMethodName());
@@ -276,6 +278,47 @@ public class AllureTestListener implements IResultListener, ISuiteListener {
         }
     }
 
+    /**
+     * Checks if the given test method is part of the current test run in matters of the include/exclude group filtering 
+     */
+    private boolean isInActiveGroup(ITestNGMethod method, ITestContext context) {
+        String[] includedGroupsArray = context.getIncludedGroups();
+        List<String> includeGroups = includedGroupsArray != null ? asList(includedGroupsArray) : Collections.<String>emptyList();
+        String[] excludedGroupsArray = context.getExcludedGroups();
+        List<String> excludeGroups = excludedGroupsArray != null ? asList(excludedGroupsArray) : Collections.<String>emptyList();
+        if (includeGroups.isEmpty()) {
+            if (excludeGroups.isEmpty()) {
+                return true; // no group restriction
+            } else {
+                if (method.getGroups() != null) {
+                    for (String group : method.getGroups()) {
+                        if (excludeGroups.contains(group)) {
+                            return false; // a group of the method is excluded
+                        }
+                    }
+                }
+                return true; // no groups of the method are excluded
+            }
+        } else {
+            if (method.getGroups() != null) {
+                boolean included = false;
+                boolean excluded = false;
+                for (String group : method.getGroups()) {
+                    if (includeGroups.contains(group)) {
+                        included = true;
+                    }
+                    if (excludeGroups.contains(group)) {
+                        excluded = true;
+                    }
+                }
+                if (included && !excluded) {
+                    return true; // a group of the method is included and not excluded
+                }
+            }
+            return false; // no groups of the method are included
+        }
+    }
+    
     private String getMethodInvocationsAndSuccessPercentage(ITestResult iTestResult) {
         int percentage = iTestResult.getMethod().getSuccessPercentage();
         int curCount = iTestResult.getMethod().getCurrentInvocationCount() + 1;

--- a/allure-testng-adaptor/src/main/java/ru/yandex/qatools/allure/testng/AllureTestListener.java
+++ b/allure-testng-adaptor/src/main/java/ru/yandex/qatools/allure/testng/AllureTestListener.java
@@ -290,35 +290,43 @@ public class AllureTestListener implements IResultListener, ISuiteListener {
             if (excludeGroups.isEmpty()) {
                 return true; // no group restriction
             } else {
-                if (method.getGroups() != null) {
-                    for (String group : method.getGroups()) {
-                        if (excludeGroups.contains(group)) {
-                            return false; // a group of the method is excluded
-                        }
-                    }
-                }
-                return true; // no groups of the method are excluded
+                return isInActiveGroupWithoutIncludes(method, excludeGroups);
             }
         } else {
-            if (method.getGroups() != null) {
-                boolean included = false;
-                boolean excluded = false;
-                for (String group : method.getGroups()) {
-                    if (includeGroups.contains(group)) {
-                        included = true;
-                    }
-                    if (excludeGroups.contains(group)) {
-                        excluded = true;
-                    }
-                }
-                if (included && !excluded) {
-                    return true; // a group of the method is included and not excluded
-                }
-            }
-            return false; // no groups of the method are included
+            return isInActiveGroupWithIncludes(method, includeGroups, excludeGroups);
         }
     }
-    
+
+    private boolean isInActiveGroupWithoutIncludes(ITestNGMethod method, List<String> excludeGroups) {
+        if (method.getGroups() != null) {
+            for (String group : method.getGroups()) {
+                if (excludeGroups.contains(group)) {
+                    return false; // a group of the method is excluded
+                }
+            }
+        }
+        return true; // no groups of the method are excluded
+    }
+
+    private boolean isInActiveGroupWithIncludes(ITestNGMethod method, List<String> includeGroups, List<String> excludeGroups) {
+        if (method.getGroups() != null) {
+            boolean included = false;
+            boolean excluded = false;
+            for (String group : method.getGroups()) {
+                if (includeGroups.contains(group)) {
+                    included = true;
+                }
+                if (excludeGroups.contains(group)) {
+                    excluded = true;
+                }
+            }
+            if (included && !excluded) {
+                return true; // a group of the method is included and not excluded
+            }
+        }
+        return false; // no groups of the method are included
+    }
+
     private String getMethodInvocationsAndSuccessPercentage(ITestResult iTestResult) {
         int percentage = iTestResult.getMethod().getSuccessPercentage();
         int curCount = iTestResult.getMethod().getCurrentInvocationCount() + 1;

--- a/allure-testng-adaptor/src/test/java/ru/yandex/qatools/allure/testng/AllureTestListenerGroupsTest.java
+++ b/allure-testng-adaptor/src/test/java/ru/yandex/qatools/allure/testng/AllureTestListenerGroupsTest.java
@@ -1,0 +1,50 @@
+package ru.yandex.qatools.allure.testng;
+
+import static java.util.Collections.*;
+import static javax.xml.bind.JAXB.unmarshal;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+import static ru.yandex.qatools.allure.commons.AllureFileUtils.*;
+
+import java.io.*;
+import java.util.*;
+import org.junit.*;
+import org.junit.rules.TemporaryFolder;
+import org.testng.TestNG;
+import ru.yandex.qatools.allure.model.*;
+import ru.yandex.qatools.allure.utils.AllureResultsUtils;
+
+public class AllureTestListenerGroupsTest {
+
+  @Rule
+  public TemporaryFolder folder = new TemporaryFolder();
+  private File resultsDir;
+
+  @Before
+  public void setUp() throws IOException {
+    resultsDir = folder.newFolder();
+    AllureResultsUtils.setResultsDirectory(resultsDir);
+  }
+
+  @Test // see https://github.com/allure-framework/allure-core/issues/880
+  public void reportContainsTestForGroups() {
+    // GIVEN: an TestNG suite with groups 
+    TestNG testNG = new TestNG(false);
+    testNG.setTestSuites(singletonList(getClass().getClassLoader().getResource("suite-groups.xml").getFile()));
+
+    // WHEN: executing
+    testNG.run();
+
+    // THEN: report only contains results for included groups
+    List<File> files = listTestSuiteFiles(resultsDir);
+    assertThat(files, hasSize(1));
+    File file = files.get(0);
+    TestSuiteResult result = unmarshal(file, TestSuiteResult.class);
+    assertThat(result.getTestCases(), hasSize(2));
+    List<String> status = new ArrayList<>();
+    for (TestCaseResult test : result.getTestCases()) {
+      status.add(test.getName() + ":" + test.getStatus());
+    }
+    assertThat(status, containsInAnyOrder("inactiveIncludedTest:PENDING", "activeIncludedTest:PASSED"));
+  }
+}

--- a/allure-testng-adaptor/src/test/java/ru/yandex/qatools/allure/testng/AllureTestListenerGroupsTest.java
+++ b/allure-testng-adaptor/src/test/java/ru/yandex/qatools/allure/testng/AllureTestListenerGroupsTest.java
@@ -16,35 +16,35 @@ import ru.yandex.qatools.allure.utils.AllureResultsUtils;
 
 public class AllureTestListenerGroupsTest {
 
-  @Rule
-  public TemporaryFolder folder = new TemporaryFolder();
-  private File resultsDir;
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+    private File resultsDir;
 
-  @Before
-  public void setUp() throws IOException {
-    resultsDir = folder.newFolder();
-    AllureResultsUtils.setResultsDirectory(resultsDir);
-  }
-
-  @Test // see https://github.com/allure-framework/allure-core/issues/880
-  public void reportContainsTestForGroups() {
-    // GIVEN: an TestNG suite with groups 
-    TestNG testNG = new TestNG(false);
-    testNG.setTestSuites(singletonList(getClass().getClassLoader().getResource("suite-groups.xml").getFile()));
-
-    // WHEN: executing
-    testNG.run();
-
-    // THEN: report only contains results for included groups
-    List<File> files = listTestSuiteFiles(resultsDir);
-    assertThat(files, hasSize(1));
-    File file = files.get(0);
-    TestSuiteResult result = unmarshal(file, TestSuiteResult.class);
-    assertThat(result.getTestCases(), hasSize(2));
-    List<String> status = new ArrayList<>();
-    for (TestCaseResult test : result.getTestCases()) {
-      status.add(test.getName() + ":" + test.getStatus());
+    @Before
+    public void setUp() throws IOException {
+        resultsDir = folder.newFolder();
+        AllureResultsUtils.setResultsDirectory(resultsDir);
     }
-    assertThat(status, containsInAnyOrder("inactiveIncludedTest:PENDING", "activeIncludedTest:PASSED"));
-  }
+
+    @Test // see https://github.com/allure-framework/allure-core/issues/880
+    public void reportContainsTestForGroups() {
+        // GIVEN: an TestNG suite with groups 
+        TestNG testNG = new TestNG(false);
+        testNG.setTestSuites(singletonList(getClass().getClassLoader().getResource("suite-groups.xml").getFile()));
+
+        // WHEN: executing
+        testNG.run();
+
+        // THEN: report only contains results for included groups
+        List<File> files = listTestSuiteFiles(resultsDir);
+        assertThat(files, hasSize(1));
+        File file = files.get(0);
+        TestSuiteResult result = unmarshal(file, TestSuiteResult.class);
+        assertThat(result.getTestCases(), hasSize(2));
+        List<String> status = new ArrayList<>();
+        for (TestCaseResult test : result.getTestCases()) {
+            status.add(test.getName() + ":" + test.getStatus());
+        }
+        assertThat(status, containsInAnyOrder("inactiveIncludedTest:PENDING", "activeIncludedTest:PASSED"));
+    }
 }

--- a/allure-testng-adaptor/src/test/java/ru/yandex/qatools/allure/testng/testdata/GroupTest.java
+++ b/allure-testng-adaptor/src/test/java/ru/yandex/qatools/allure/testng/testdata/GroupTest.java
@@ -1,0 +1,34 @@
+package ru.yandex.qatools.allure.testng.testdata;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+import static org.testng.Assert.fail;
+
+import org.testng.annotations.*;
+
+public class GroupTest {
+
+    @Test
+    public void activeTest() { }
+
+    @Test(enabled = false)
+    public void inactiveTest() { }
+
+    @Test(groups = "include")
+    public void activeIncludedTest() { }
+
+    @Test(groups = "include", enabled = false)
+    public void inactiveIncludedTest() { }
+    
+    @Test(groups = "exclude")
+    public void activeExcludedTest() { }
+
+    @Test(groups = "exclude", enabled = false)
+    public void inactiveExcludedTest() { }
+
+    @Test(groups = {"include", "exclude"})
+    public void activeIncludedExcludedTest() { }
+
+    @Test(groups = {"include", "exclude"}, enabled = false)
+    public void inactiveIncludedExcludedTest() { }
+}

--- a/allure-testng-adaptor/src/test/resources/suite-groups.xml
+++ b/allure-testng-adaptor/src/test/resources/suite-groups.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
+<suite name="Test suite with groups">
+    <test name="Test with groups">
+        <groups>
+            <run>
+                <include name="include"/>
+                <exclude name="exclude"/>
+            </run>
+        </groups>
+        <classes>
+            <class name="ru.yandex.qatools.allure.testng.testdata.GroupTest"/>
+        </classes>
+    </test>
+</suite>


### PR DESCRIPTION
This fixes the issue described in #880